### PR TITLE
workaround(api) Don't fail on unknown properties

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -122,11 +122,11 @@ func (c *Client) VerifyDomain(
 func (c *Client) UpdateWorkspaceConnections(
 	teamId int, domainName string, connections PathToWorkspaces,
 ) (*Domain, error) {
-	req := make(map[string][]float32)
+	req := make(map[string][]int)
 	for path, workspaces := range connections {
-		ids := make([]float32, len(workspaces))
+		ids := make([]int, len(workspaces))
 		for i, w := range workspaces {
-			ids[i] = float32(w.Id)
+			ids[i] = w.Id
 		}
 		req[path] = ids
 	}

--- a/api/openapi_client/api_domains.go
+++ b/api/openapi_client/api_domains.go
@@ -699,10 +699,10 @@ type ApiDomainsUpdateWorkspaceConnectionsRequest struct {
 	ApiService  *DomainsAPIService
 	teamId      float32
 	domainName  string
-	requestBody *map[string][]float32
+	requestBody *map[string][]int
 }
 
-func (r ApiDomainsUpdateWorkspaceConnectionsRequest) RequestBody(requestBody map[string][]float32) ApiDomainsUpdateWorkspaceConnectionsRequest {
+func (r ApiDomainsUpdateWorkspaceConnectionsRequest) RequestBody(requestBody map[string][]int) ApiDomainsUpdateWorkspaceConnectionsRequest {
 	r.requestBody = &requestBody
 	return r
 }

--- a/api/openapi_client/api_workspaces.go
+++ b/api/openapi_client/api_workspaces.go
@@ -406,7 +406,6 @@ type ApiWorkspacesDeployLandscapeRequest struct {
 	ctx         context.Context
 	ApiService  *WorkspacesAPIService
 	workspaceId float32
-	profile     string
 }
 
 func (r ApiWorkspacesDeployLandscapeRequest) Execute() (*http.Response, error) {
@@ -418,15 +417,13 @@ WorkspacesDeployLandscape deployLandscape
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param workspaceId
-	@param profile
 	@return ApiWorkspacesDeployLandscapeRequest
 */
-func (a *WorkspacesAPIService) WorkspacesDeployLandscape(ctx context.Context, workspaceId float32, profile string) ApiWorkspacesDeployLandscapeRequest {
+func (a *WorkspacesAPIService) WorkspacesDeployLandscape(ctx context.Context, workspaceId float32) ApiWorkspacesDeployLandscapeRequest {
 	return ApiWorkspacesDeployLandscapeRequest{
 		ApiService:  a,
 		ctx:         ctx,
 		workspaceId: workspaceId,
-		profile:     profile,
 	}
 }
 
@@ -443,9 +440,8 @@ func (a *WorkspacesAPIService) WorkspacesDeployLandscapeExecute(r ApiWorkspacesD
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/workspaces/{workspaceId}/landscape/deploy/{profile}"
+	localVarPath := localBasePath + "/workspaces/{workspaceId}/landscape/deploy"
 	localVarPath = strings.Replace(localVarPath, "{"+"workspaceId"+"}", url.PathEscape(parameterValueToString(r.workspaceId, "workspaceId")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"profile"+"}", url.PathEscape(parameterValueToString(r.profile, "profile")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -528,46 +524,50 @@ func (a *WorkspacesAPIService) WorkspacesDeployLandscapeExecute(r ApiWorkspacesD
 	return localVarHTTPResponse, nil
 }
 
-type ApiWorkspacesDeployLandscape_0Request struct {
+type ApiWorkspacesDeployLandscape1Request struct {
 	ctx         context.Context
 	ApiService  *WorkspacesAPIService
 	workspaceId float32
+	profile     string
 }
 
-func (r ApiWorkspacesDeployLandscape_0Request) Execute() (*http.Response, error) {
-	return r.ApiService.WorkspacesDeployLandscape_1Execute(r)
+func (r ApiWorkspacesDeployLandscape1Request) Execute() (*http.Response, error) {
+	return r.ApiService.WorkspacesDeployLandscape1Execute(r)
 }
 
 /*
-WorkspacesDeployLandscape_0 deployLandscape
+WorkspacesDeployLandscape1 deployLandscape
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param workspaceId
-	@return ApiWorkspacesDeployLandscape_0Request
+	@param profile
+	@return ApiWorkspacesDeployLandscape1Request
 */
-func (a *WorkspacesAPIService) WorkspacesDeployLandscape_1(ctx context.Context, workspaceId float32) ApiWorkspacesDeployLandscape_0Request {
-	return ApiWorkspacesDeployLandscape_0Request{
+func (a *WorkspacesAPIService) WorkspacesDeployLandscape1(ctx context.Context, workspaceId float32, profile string) ApiWorkspacesDeployLandscape1Request {
+	return ApiWorkspacesDeployLandscape1Request{
 		ApiService:  a,
 		ctx:         ctx,
 		workspaceId: workspaceId,
+		profile:     profile,
 	}
 }
 
 // Execute executes the request
-func (a *WorkspacesAPIService) WorkspacesDeployLandscape_1Execute(r ApiWorkspacesDeployLandscape_0Request) (*http.Response, error) {
+func (a *WorkspacesAPIService) WorkspacesDeployLandscape1Execute(r ApiWorkspacesDeployLandscape1Request) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
 		formFiles          []formFile
 	)
 
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspacesAPIService.WorkspacesDeployLandscape_1")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspacesAPIService.WorkspacesDeployLandscape1")
 	if err != nil {
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/workspaces/{workspaceId}/landscape/deploy"
+	localVarPath := localBasePath + "/workspaces/{workspaceId}/landscape/deploy/{profile}"
 	localVarPath = strings.Replace(localVarPath, "{"+"workspaceId"+"}", url.PathEscape(parameterValueToString(r.workspaceId, "workspaceId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"profile"+"}", url.PathEscape(parameterValueToString(r.profile, "profile")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1200,8 +1200,6 @@ type ApiWorkspacesGitPullRequest struct {
 	ctx         context.Context
 	ApiService  *WorkspacesAPIService
 	workspaceId float32
-	remote      string
-	branch      string
 }
 
 func (r ApiWorkspacesGitPullRequest) Execute() (*http.Response, error) {
@@ -1213,17 +1211,13 @@ WorkspacesGitPull gitPull
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param workspaceId
-	@param remote
-	@param branch
 	@return ApiWorkspacesGitPullRequest
 */
-func (a *WorkspacesAPIService) WorkspacesGitPull(ctx context.Context, workspaceId float32, remote string, branch string) ApiWorkspacesGitPullRequest {
+func (a *WorkspacesAPIService) WorkspacesGitPull(ctx context.Context, workspaceId float32) ApiWorkspacesGitPullRequest {
 	return ApiWorkspacesGitPullRequest{
 		ApiService:  a,
 		ctx:         ctx,
 		workspaceId: workspaceId,
-		remote:      remote,
-		branch:      branch,
 	}
 }
 
@@ -1240,10 +1234,8 @@ func (a *WorkspacesAPIService) WorkspacesGitPullExecute(r ApiWorkspacesGitPullRe
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/workspaces/{workspaceId}/git/pull/{remote}/{branch}"
+	localVarPath := localBasePath + "/workspaces/{workspaceId}/git/pull"
 	localVarPath = strings.Replace(localVarPath, "{"+"workspaceId"+"}", url.PathEscape(parameterValueToString(r.workspaceId, "workspaceId")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"remote"+"}", url.PathEscape(parameterValueToString(r.remote, "remote")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"branch"+"}", url.PathEscape(parameterValueToString(r.branch, "branch")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1326,27 +1318,27 @@ func (a *WorkspacesAPIService) WorkspacesGitPullExecute(r ApiWorkspacesGitPullRe
 	return localVarHTTPResponse, nil
 }
 
-type ApiWorkspacesGitPull_0Request struct {
+type ApiWorkspacesGitPull1Request struct {
 	ctx         context.Context
 	ApiService  *WorkspacesAPIService
 	workspaceId float32
 	remote      string
 }
 
-func (r ApiWorkspacesGitPull_0Request) Execute() (*http.Response, error) {
-	return r.ApiService.WorkspacesGitPull_2Execute(r)
+func (r ApiWorkspacesGitPull1Request) Execute() (*http.Response, error) {
+	return r.ApiService.WorkspacesGitPull1Execute(r)
 }
 
 /*
-WorkspacesGitPull_0 gitPull
+WorkspacesGitPull1 gitPull
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param workspaceId
 	@param remote
-	@return ApiWorkspacesGitPull_0Request
+	@return ApiWorkspacesGitPull1Request
 */
-func (a *WorkspacesAPIService) WorkspacesGitPull_2(ctx context.Context, workspaceId float32, remote string) ApiWorkspacesGitPull_0Request {
-	return ApiWorkspacesGitPull_0Request{
+func (a *WorkspacesAPIService) WorkspacesGitPull1(ctx context.Context, workspaceId float32, remote string) ApiWorkspacesGitPull1Request {
+	return ApiWorkspacesGitPull1Request{
 		ApiService:  a,
 		ctx:         ctx,
 		workspaceId: workspaceId,
@@ -1355,14 +1347,14 @@ func (a *WorkspacesAPIService) WorkspacesGitPull_2(ctx context.Context, workspac
 }
 
 // Execute executes the request
-func (a *WorkspacesAPIService) WorkspacesGitPull_2Execute(r ApiWorkspacesGitPull_0Request) (*http.Response, error) {
+func (a *WorkspacesAPIService) WorkspacesGitPull1Execute(r ApiWorkspacesGitPull1Request) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
 		formFiles          []formFile
 	)
 
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspacesAPIService.WorkspacesGitPull_2")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspacesAPIService.WorkspacesGitPull1")
 	if err != nil {
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
@@ -1452,46 +1444,54 @@ func (a *WorkspacesAPIService) WorkspacesGitPull_2Execute(r ApiWorkspacesGitPull
 	return localVarHTTPResponse, nil
 }
 
-type ApiWorkspacesGitPull_1Request struct {
+type ApiWorkspacesGitPull2Request struct {
 	ctx         context.Context
 	ApiService  *WorkspacesAPIService
 	workspaceId float32
+	remote      string
+	branch      string
 }
 
-func (r ApiWorkspacesGitPull_1Request) Execute() (*http.Response, error) {
-	return r.ApiService.WorkspacesGitPull_3Execute(r)
+func (r ApiWorkspacesGitPull2Request) Execute() (*http.Response, error) {
+	return r.ApiService.WorkspacesGitPull2Execute(r)
 }
 
 /*
-WorkspacesGitPull_1 gitPull
+WorkspacesGitPull2 gitPull
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param workspaceId
-	@return ApiWorkspacesGitPull_1Request
+	@param remote
+	@param branch
+	@return ApiWorkspacesGitPull2Request
 */
-func (a *WorkspacesAPIService) WorkspacesGitPull_3(ctx context.Context, workspaceId float32) ApiWorkspacesGitPull_1Request {
-	return ApiWorkspacesGitPull_1Request{
+func (a *WorkspacesAPIService) WorkspacesGitPull2(ctx context.Context, workspaceId float32, remote string, branch string) ApiWorkspacesGitPull2Request {
+	return ApiWorkspacesGitPull2Request{
 		ApiService:  a,
 		ctx:         ctx,
 		workspaceId: workspaceId,
+		remote:      remote,
+		branch:      branch,
 	}
 }
 
 // Execute executes the request
-func (a *WorkspacesAPIService) WorkspacesGitPull_3Execute(r ApiWorkspacesGitPull_1Request) (*http.Response, error) {
+func (a *WorkspacesAPIService) WorkspacesGitPull2Execute(r ApiWorkspacesGitPull2Request) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
 		formFiles          []formFile
 	)
 
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspacesAPIService.WorkspacesGitPull_3")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspacesAPIService.WorkspacesGitPull2")
 	if err != nil {
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/workspaces/{workspaceId}/git/pull"
+	localVarPath := localBasePath + "/workspaces/{workspaceId}/git/pull/{remote}/{branch}"
 	localVarPath = strings.Replace(localVarPath, "{"+"workspaceId"+"}", url.PathEscape(parameterValueToString(r.workspaceId, "workspaceId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"remote"+"}", url.PathEscape(parameterValueToString(r.remote, "remote")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"branch"+"}", url.PathEscape(parameterValueToString(r.branch, "branch")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -2436,7 +2436,6 @@ type ApiWorkspacesStartPipelineStageRequest struct {
 	ApiService  *WorkspacesAPIService
 	workspaceId float32
 	stage       string
-	profile     string
 }
 
 func (r ApiWorkspacesStartPipelineStageRequest) Execute() (*http.Response, error) {
@@ -2449,16 +2448,14 @@ WorkspacesStartPipelineStage startPipelineStage
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param workspaceId
 	@param stage
-	@param profile
 	@return ApiWorkspacesStartPipelineStageRequest
 */
-func (a *WorkspacesAPIService) WorkspacesStartPipelineStage(ctx context.Context, workspaceId float32, stage string, profile string) ApiWorkspacesStartPipelineStageRequest {
+func (a *WorkspacesAPIService) WorkspacesStartPipelineStage(ctx context.Context, workspaceId float32, stage string) ApiWorkspacesStartPipelineStageRequest {
 	return ApiWorkspacesStartPipelineStageRequest{
 		ApiService:  a,
 		ctx:         ctx,
 		workspaceId: workspaceId,
 		stage:       stage,
-		profile:     profile,
 	}
 }
 
@@ -2475,10 +2472,9 @@ func (a *WorkspacesAPIService) WorkspacesStartPipelineStageExecute(r ApiWorkspac
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/workspaces/{workspaceId}/pipeline/{stage}/start/{profile}"
+	localVarPath := localBasePath + "/workspaces/{workspaceId}/pipeline/{stage}/start"
 	localVarPath = strings.Replace(localVarPath, "{"+"workspaceId"+"}", url.PathEscape(parameterValueToString(r.workspaceId, "workspaceId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"stage"+"}", url.PathEscape(parameterValueToString(r.stage, "stage")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"profile"+"}", url.PathEscape(parameterValueToString(r.profile, "profile")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -2561,50 +2557,54 @@ func (a *WorkspacesAPIService) WorkspacesStartPipelineStageExecute(r ApiWorkspac
 	return localVarHTTPResponse, nil
 }
 
-type ApiWorkspacesStartPipelineStage_0Request struct {
+type ApiWorkspacesStartPipelineStage1Request struct {
 	ctx         context.Context
 	ApiService  *WorkspacesAPIService
 	workspaceId float32
 	stage       string
+	profile     string
 }
 
-func (r ApiWorkspacesStartPipelineStage_0Request) Execute() (*http.Response, error) {
-	return r.ApiService.WorkspacesStartPipelineStage_4Execute(r)
+func (r ApiWorkspacesStartPipelineStage1Request) Execute() (*http.Response, error) {
+	return r.ApiService.WorkspacesStartPipelineStage1Execute(r)
 }
 
 /*
-WorkspacesStartPipelineStage_0 startPipelineStage
+WorkspacesStartPipelineStage1 startPipelineStage
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param workspaceId
 	@param stage
-	@return ApiWorkspacesStartPipelineStage_0Request
+	@param profile
+	@return ApiWorkspacesStartPipelineStage1Request
 */
-func (a *WorkspacesAPIService) WorkspacesStartPipelineStage_4(ctx context.Context, workspaceId float32, stage string) ApiWorkspacesStartPipelineStage_0Request {
-	return ApiWorkspacesStartPipelineStage_0Request{
+func (a *WorkspacesAPIService) WorkspacesStartPipelineStage1(ctx context.Context, workspaceId float32, stage string, profile string) ApiWorkspacesStartPipelineStage1Request {
+	return ApiWorkspacesStartPipelineStage1Request{
 		ApiService:  a,
 		ctx:         ctx,
 		workspaceId: workspaceId,
 		stage:       stage,
+		profile:     profile,
 	}
 }
 
 // Execute executes the request
-func (a *WorkspacesAPIService) WorkspacesStartPipelineStage_4Execute(r ApiWorkspacesStartPipelineStage_0Request) (*http.Response, error) {
+func (a *WorkspacesAPIService) WorkspacesStartPipelineStage1Execute(r ApiWorkspacesStartPipelineStage1Request) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodPost
 		localVarPostBody   interface{}
 		formFiles          []formFile
 	)
 
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspacesAPIService.WorkspacesStartPipelineStage_4")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspacesAPIService.WorkspacesStartPipelineStage1")
 	if err != nil {
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/workspaces/{workspaceId}/pipeline/{stage}/start"
+	localVarPath := localBasePath + "/workspaces/{workspaceId}/pipeline/{stage}/start/{profile}"
 	localVarPath = strings.Replace(localVarPath, "{"+"workspaceId"+"}", url.PathEscape(parameterValueToString(r.workspaceId, "workspaceId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"stage"+"}", url.PathEscape(parameterValueToString(r.stage, "stage")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"profile"+"}", url.PathEscape(parameterValueToString(r.profile, "profile")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/api/openapi_client/model__problem.go
+++ b/api/openapi_client/model__problem.go
@@ -136,7 +136,7 @@ func (o *Problem) UnmarshalJSON(data []byte) (err error) {
 	varProblem := _Problem{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varProblem)
 
 	if err != nil {

--- a/api/openapi_client/model__problem_data.go
+++ b/api/openapi_client/model__problem_data.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &ProblemData{}
 type ProblemData struct {
 	Status  int     `json:"status"`
 	Title   string  `json:"title"`
-	Details *string `json:"details,omitempty"`
+	Detail  *string `json:"detail,omitempty"`
 	TraceId string  `json:"traceId"`
 }
 
@@ -98,36 +98,36 @@ func (o *ProblemData) SetTitle(v string) {
 	o.Title = v
 }
 
-// GetDetails returns the Details field value if set, zero value otherwise.
-func (o *ProblemData) GetDetails() string {
-	if o == nil || IsNil(o.Details) {
+// GetDetail returns the Detail field value if set, zero value otherwise.
+func (o *ProblemData) GetDetail() string {
+	if o == nil || IsNil(o.Detail) {
 		var ret string
 		return ret
 	}
-	return *o.Details
+	return *o.Detail
 }
 
-// GetDetailsOk returns a tuple with the Details field value if set, nil otherwise
+// GetDetailOk returns a tuple with the Detail field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ProblemData) GetDetailsOk() (*string, bool) {
-	if o == nil || IsNil(o.Details) {
+func (o *ProblemData) GetDetailOk() (*string, bool) {
+	if o == nil || IsNil(o.Detail) {
 		return nil, false
 	}
-	return o.Details, true
+	return o.Detail, true
 }
 
-// HasDetails returns a boolean if a field has been set.
-func (o *ProblemData) HasDetails() bool {
-	if o != nil && !IsNil(o.Details) {
+// HasDetail returns a boolean if a field has been set.
+func (o *ProblemData) HasDetail() bool {
+	if o != nil && !IsNil(o.Detail) {
 		return true
 	}
 
 	return false
 }
 
-// SetDetails gets a reference to the given string and assigns it to the Details field.
-func (o *ProblemData) SetDetails(v string) {
-	o.Details = &v
+// SetDetail gets a reference to the given string and assigns it to the Detail field.
+func (o *ProblemData) SetDetail(v string) {
+	o.Detail = &v
 }
 
 // GetTraceId returns the TraceId field value
@@ -166,8 +166,8 @@ func (o ProblemData) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["status"] = o.Status
 	toSerialize["title"] = o.Title
-	if !IsNil(o.Details) {
-		toSerialize["details"] = o.Details
+	if !IsNil(o.Detail) {
+		toSerialize["detail"] = o.Detail
 	}
 	toSerialize["traceId"] = o.TraceId
 	return toSerialize, nil
@@ -200,7 +200,7 @@ func (o *ProblemData) UnmarshalJSON(data []byte) (err error) {
 	varProblemData := _ProblemData{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varProblemData)
 
 	if err != nil {

--- a/api/openapi_client/model_domains_get_domain_200_response.go
+++ b/api/openapi_client/model_domains_get_domain_200_response.go
@@ -22,14 +22,14 @@ var _ MappedNullable = &DomainsGetDomain200Response{}
 
 // DomainsGetDomain200Response struct for DomainsGetDomain200Response
 type DomainsGetDomain200Response struct {
-	TeamId                   float32                                             `json:"teamId"`
+	TeamId                   int                                                 `json:"teamId"`
 	DataCenterId             int                                                 `json:"dataCenterId"`
-	Workspaces               map[string][]float32                                `json:"workspaces"`
+	Workspaces               map[string][]int                                    `json:"workspaces"`
 	Name                     string                                              `json:"name"`
 	CertificateRequestStatus DomainsGetDomain200ResponseCertificateRequestStatus `json:"certificateRequestStatus"`
 	DnsEntries               DomainsGetDomain200ResponseDnsEntries               `json:"dnsEntries"`
 	DomainVerificationStatus DomainsGetDomain200ResponseDomainVerificationStatus `json:"domainVerificationStatus"`
-	CustomConfigRevision     *float32                                            `json:"customConfigRevision,omitempty"`
+	CustomConfigRevision     *int                                                `json:"customConfigRevision,omitempty"`
 	CustomConfig             *DomainsGetDomain200ResponseCustomConfig            `json:"customConfig,omitempty"`
 }
 
@@ -39,7 +39,7 @@ type _DomainsGetDomain200Response DomainsGetDomain200Response
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewDomainsGetDomain200Response(teamId float32, dataCenterId int, workspaces map[string][]float32, name string, certificateRequestStatus DomainsGetDomain200ResponseCertificateRequestStatus, dnsEntries DomainsGetDomain200ResponseDnsEntries, domainVerificationStatus DomainsGetDomain200ResponseDomainVerificationStatus) *DomainsGetDomain200Response {
+func NewDomainsGetDomain200Response(teamId int, dataCenterId int, workspaces map[string][]int, name string, certificateRequestStatus DomainsGetDomain200ResponseCertificateRequestStatus, dnsEntries DomainsGetDomain200ResponseDnsEntries, domainVerificationStatus DomainsGetDomain200ResponseDomainVerificationStatus) *DomainsGetDomain200Response {
 	this := DomainsGetDomain200Response{}
 	this.TeamId = teamId
 	this.DataCenterId = dataCenterId
@@ -60,9 +60,9 @@ func NewDomainsGetDomain200ResponseWithDefaults() *DomainsGetDomain200Response {
 }
 
 // GetTeamId returns the TeamId field value
-func (o *DomainsGetDomain200Response) GetTeamId() float32 {
+func (o *DomainsGetDomain200Response) GetTeamId() int {
 	if o == nil {
-		var ret float32
+		var ret int
 		return ret
 	}
 
@@ -71,7 +71,7 @@ func (o *DomainsGetDomain200Response) GetTeamId() float32 {
 
 // GetTeamIdOk returns a tuple with the TeamId field value
 // and a boolean to check if the value has been set.
-func (o *DomainsGetDomain200Response) GetTeamIdOk() (*float32, bool) {
+func (o *DomainsGetDomain200Response) GetTeamIdOk() (*int, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -79,7 +79,7 @@ func (o *DomainsGetDomain200Response) GetTeamIdOk() (*float32, bool) {
 }
 
 // SetTeamId sets field value
-func (o *DomainsGetDomain200Response) SetTeamId(v float32) {
+func (o *DomainsGetDomain200Response) SetTeamId(v int) {
 	o.TeamId = v
 }
 
@@ -108,9 +108,9 @@ func (o *DomainsGetDomain200Response) SetDataCenterId(v int) {
 }
 
 // GetWorkspaces returns the Workspaces field value
-func (o *DomainsGetDomain200Response) GetWorkspaces() map[string][]float32 {
+func (o *DomainsGetDomain200Response) GetWorkspaces() map[string][]int {
 	if o == nil {
-		var ret map[string][]float32
+		var ret map[string][]int
 		return ret
 	}
 
@@ -119,7 +119,7 @@ func (o *DomainsGetDomain200Response) GetWorkspaces() map[string][]float32 {
 
 // GetWorkspacesOk returns a tuple with the Workspaces field value
 // and a boolean to check if the value has been set.
-func (o *DomainsGetDomain200Response) GetWorkspacesOk() (*map[string][]float32, bool) {
+func (o *DomainsGetDomain200Response) GetWorkspacesOk() (*map[string][]int, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -127,7 +127,7 @@ func (o *DomainsGetDomain200Response) GetWorkspacesOk() (*map[string][]float32, 
 }
 
 // SetWorkspaces sets field value
-func (o *DomainsGetDomain200Response) SetWorkspaces(v map[string][]float32) {
+func (o *DomainsGetDomain200Response) SetWorkspaces(v map[string][]int) {
 	o.Workspaces = v
 }
 
@@ -228,9 +228,9 @@ func (o *DomainsGetDomain200Response) SetDomainVerificationStatus(v DomainsGetDo
 }
 
 // GetCustomConfigRevision returns the CustomConfigRevision field value if set, zero value otherwise.
-func (o *DomainsGetDomain200Response) GetCustomConfigRevision() float32 {
+func (o *DomainsGetDomain200Response) GetCustomConfigRevision() int {
 	if o == nil || IsNil(o.CustomConfigRevision) {
-		var ret float32
+		var ret int
 		return ret
 	}
 	return *o.CustomConfigRevision
@@ -238,7 +238,7 @@ func (o *DomainsGetDomain200Response) GetCustomConfigRevision() float32 {
 
 // GetCustomConfigRevisionOk returns a tuple with the CustomConfigRevision field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DomainsGetDomain200Response) GetCustomConfigRevisionOk() (*float32, bool) {
+func (o *DomainsGetDomain200Response) GetCustomConfigRevisionOk() (*int, bool) {
 	if o == nil || IsNil(o.CustomConfigRevision) {
 		return nil, false
 	}
@@ -254,8 +254,8 @@ func (o *DomainsGetDomain200Response) HasCustomConfigRevision() bool {
 	return false
 }
 
-// SetCustomConfigRevision gets a reference to the given float32 and assigns it to the CustomConfigRevision field.
-func (o *DomainsGetDomain200Response) SetCustomConfigRevision(v float32) {
+// SetCustomConfigRevision gets a reference to the given int and assigns it to the CustomConfigRevision field.
+func (o *DomainsGetDomain200Response) SetCustomConfigRevision(v int) {
 	o.CustomConfigRevision = &v
 }
 
@@ -348,7 +348,7 @@ func (o *DomainsGetDomain200Response) UnmarshalJSON(data []byte) (err error) {
 	varDomainsGetDomain200Response := _DomainsGetDomain200Response{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDomainsGetDomain200Response)
 
 	if err != nil {

--- a/api/openapi_client/model_domains_get_domain_200_response_certificate_request_status.go
+++ b/api/openapi_client/model_domains_get_domain_200_response_certificate_request_status.go
@@ -138,7 +138,7 @@ func (o *DomainsGetDomain200ResponseCertificateRequestStatus) UnmarshalJSON(data
 	varDomainsGetDomain200ResponseCertificateRequestStatus := _DomainsGetDomain200ResponseCertificateRequestStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDomainsGetDomain200ResponseCertificateRequestStatus)
 
 	if err != nil {

--- a/api/openapi_client/model_domains_get_domain_200_response_dns_entries.go
+++ b/api/openapi_client/model_domains_get_domain_200_response_dns_entries.go
@@ -164,7 +164,7 @@ func (o *DomainsGetDomain200ResponseDnsEntries) UnmarshalJSON(data []byte) (err 
 	varDomainsGetDomain200ResponseDnsEntries := _DomainsGetDomain200ResponseDnsEntries{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDomainsGetDomain200ResponseDnsEntries)
 
 	if err != nil {

--- a/api/openapi_client/model_domains_get_domain_200_response_domain_verification_status.go
+++ b/api/openapi_client/model_domains_get_domain_200_response_domain_verification_status.go
@@ -138,7 +138,7 @@ func (o *DomainsGetDomain200ResponseDomainVerificationStatus) UnmarshalJSON(data
 	varDomainsGetDomain200ResponseDomainVerificationStatus := _DomainsGetDomain200ResponseDomainVerificationStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDomainsGetDomain200ResponseDomainVerificationStatus)
 
 	if err != nil {

--- a/api/openapi_client/model_domains_get_domain_400_response.go
+++ b/api/openapi_client/model_domains_get_domain_400_response.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &DomainsGetDomain400Response{}
 type DomainsGetDomain400Response struct {
 	Status  int     `json:"status"`
 	Title   string  `json:"title"`
-	Details *string `json:"details,omitempty"`
+	Detail  *string `json:"detail,omitempty"`
 	TraceId string  `json:"traceId"`
 }
 
@@ -98,36 +98,36 @@ func (o *DomainsGetDomain400Response) SetTitle(v string) {
 	o.Title = v
 }
 
-// GetDetails returns the Details field value if set, zero value otherwise.
-func (o *DomainsGetDomain400Response) GetDetails() string {
-	if o == nil || IsNil(o.Details) {
+// GetDetail returns the Detail field value if set, zero value otherwise.
+func (o *DomainsGetDomain400Response) GetDetail() string {
+	if o == nil || IsNil(o.Detail) {
 		var ret string
 		return ret
 	}
-	return *o.Details
+	return *o.Detail
 }
 
-// GetDetailsOk returns a tuple with the Details field value if set, nil otherwise
+// GetDetailOk returns a tuple with the Detail field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DomainsGetDomain400Response) GetDetailsOk() (*string, bool) {
-	if o == nil || IsNil(o.Details) {
+func (o *DomainsGetDomain400Response) GetDetailOk() (*string, bool) {
+	if o == nil || IsNil(o.Detail) {
 		return nil, false
 	}
-	return o.Details, true
+	return o.Detail, true
 }
 
-// HasDetails returns a boolean if a field has been set.
-func (o *DomainsGetDomain400Response) HasDetails() bool {
-	if o != nil && !IsNil(o.Details) {
+// HasDetail returns a boolean if a field has been set.
+func (o *DomainsGetDomain400Response) HasDetail() bool {
+	if o != nil && !IsNil(o.Detail) {
 		return true
 	}
 
 	return false
 }
 
-// SetDetails gets a reference to the given string and assigns it to the Details field.
-func (o *DomainsGetDomain400Response) SetDetails(v string) {
-	o.Details = &v
+// SetDetail gets a reference to the given string and assigns it to the Detail field.
+func (o *DomainsGetDomain400Response) SetDetail(v string) {
+	o.Detail = &v
 }
 
 // GetTraceId returns the TraceId field value
@@ -166,8 +166,8 @@ func (o DomainsGetDomain400Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["status"] = o.Status
 	toSerialize["title"] = o.Title
-	if !IsNil(o.Details) {
-		toSerialize["details"] = o.Details
+	if !IsNil(o.Detail) {
+		toSerialize["detail"] = o.Detail
 	}
 	toSerialize["traceId"] = o.TraceId
 	return toSerialize, nil
@@ -200,7 +200,7 @@ func (o *DomainsGetDomain400Response) UnmarshalJSON(data []byte) (err error) {
 	varDomainsGetDomain400Response := _DomainsGetDomain400Response{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDomainsGetDomain400Response)
 
 	if err != nil {

--- a/api/openapi_client/model_domains_get_domain_401_response.go
+++ b/api/openapi_client/model_domains_get_domain_401_response.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &DomainsGetDomain401Response{}
 type DomainsGetDomain401Response struct {
 	Status  int     `json:"status"`
 	Title   string  `json:"title"`
-	Details *string `json:"details,omitempty"`
+	Detail  *string `json:"detail,omitempty"`
 	TraceId string  `json:"traceId"`
 }
 
@@ -98,36 +98,36 @@ func (o *DomainsGetDomain401Response) SetTitle(v string) {
 	o.Title = v
 }
 
-// GetDetails returns the Details field value if set, zero value otherwise.
-func (o *DomainsGetDomain401Response) GetDetails() string {
-	if o == nil || IsNil(o.Details) {
+// GetDetail returns the Detail field value if set, zero value otherwise.
+func (o *DomainsGetDomain401Response) GetDetail() string {
+	if o == nil || IsNil(o.Detail) {
 		var ret string
 		return ret
 	}
-	return *o.Details
+	return *o.Detail
 }
 
-// GetDetailsOk returns a tuple with the Details field value if set, nil otherwise
+// GetDetailOk returns a tuple with the Detail field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DomainsGetDomain401Response) GetDetailsOk() (*string, bool) {
-	if o == nil || IsNil(o.Details) {
+func (o *DomainsGetDomain401Response) GetDetailOk() (*string, bool) {
+	if o == nil || IsNil(o.Detail) {
 		return nil, false
 	}
-	return o.Details, true
+	return o.Detail, true
 }
 
-// HasDetails returns a boolean if a field has been set.
-func (o *DomainsGetDomain401Response) HasDetails() bool {
-	if o != nil && !IsNil(o.Details) {
+// HasDetail returns a boolean if a field has been set.
+func (o *DomainsGetDomain401Response) HasDetail() bool {
+	if o != nil && !IsNil(o.Detail) {
 		return true
 	}
 
 	return false
 }
 
-// SetDetails gets a reference to the given string and assigns it to the Details field.
-func (o *DomainsGetDomain401Response) SetDetails(v string) {
-	o.Details = &v
+// SetDetail gets a reference to the given string and assigns it to the Detail field.
+func (o *DomainsGetDomain401Response) SetDetail(v string) {
+	o.Detail = &v
 }
 
 // GetTraceId returns the TraceId field value
@@ -166,8 +166,8 @@ func (o DomainsGetDomain401Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["status"] = o.Status
 	toSerialize["title"] = o.Title
-	if !IsNil(o.Details) {
-		toSerialize["details"] = o.Details
+	if !IsNil(o.Detail) {
+		toSerialize["detail"] = o.Detail
 	}
 	toSerialize["traceId"] = o.TraceId
 	return toSerialize, nil
@@ -200,7 +200,7 @@ func (o *DomainsGetDomain401Response) UnmarshalJSON(data []byte) (err error) {
 	varDomainsGetDomain401Response := _DomainsGetDomain401Response{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDomainsGetDomain401Response)
 
 	if err != nil {

--- a/api/openapi_client/model_domains_get_domain_404_response.go
+++ b/api/openapi_client/model_domains_get_domain_404_response.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &DomainsGetDomain404Response{}
 type DomainsGetDomain404Response struct {
 	Status  int     `json:"status"`
 	Title   string  `json:"title"`
-	Details *string `json:"details,omitempty"`
+	Detail  *string `json:"detail,omitempty"`
 	TraceId string  `json:"traceId"`
 }
 
@@ -98,36 +98,36 @@ func (o *DomainsGetDomain404Response) SetTitle(v string) {
 	o.Title = v
 }
 
-// GetDetails returns the Details field value if set, zero value otherwise.
-func (o *DomainsGetDomain404Response) GetDetails() string {
-	if o == nil || IsNil(o.Details) {
+// GetDetail returns the Detail field value if set, zero value otherwise.
+func (o *DomainsGetDomain404Response) GetDetail() string {
+	if o == nil || IsNil(o.Detail) {
 		var ret string
 		return ret
 	}
-	return *o.Details
+	return *o.Detail
 }
 
-// GetDetailsOk returns a tuple with the Details field value if set, nil otherwise
+// GetDetailOk returns a tuple with the Detail field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DomainsGetDomain404Response) GetDetailsOk() (*string, bool) {
-	if o == nil || IsNil(o.Details) {
+func (o *DomainsGetDomain404Response) GetDetailOk() (*string, bool) {
+	if o == nil || IsNil(o.Detail) {
 		return nil, false
 	}
-	return o.Details, true
+	return o.Detail, true
 }
 
-// HasDetails returns a boolean if a field has been set.
-func (o *DomainsGetDomain404Response) HasDetails() bool {
-	if o != nil && !IsNil(o.Details) {
+// HasDetail returns a boolean if a field has been set.
+func (o *DomainsGetDomain404Response) HasDetail() bool {
+	if o != nil && !IsNil(o.Detail) {
 		return true
 	}
 
 	return false
 }
 
-// SetDetails gets a reference to the given string and assigns it to the Details field.
-func (o *DomainsGetDomain404Response) SetDetails(v string) {
-	o.Details = &v
+// SetDetail gets a reference to the given string and assigns it to the Detail field.
+func (o *DomainsGetDomain404Response) SetDetail(v string) {
+	o.Detail = &v
 }
 
 // GetTraceId returns the TraceId field value
@@ -166,8 +166,8 @@ func (o DomainsGetDomain404Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["status"] = o.Status
 	toSerialize["title"] = o.Title
-	if !IsNil(o.Details) {
-		toSerialize["details"] = o.Details
+	if !IsNil(o.Detail) {
+		toSerialize["detail"] = o.Detail
 	}
 	toSerialize["traceId"] = o.TraceId
 	return toSerialize, nil
@@ -200,7 +200,7 @@ func (o *DomainsGetDomain404Response) UnmarshalJSON(data []byte) (err error) {
 	varDomainsGetDomain404Response := _DomainsGetDomain404Response{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDomainsGetDomain404Response)
 
 	if err != nil {

--- a/api/openapi_client/model_domains_update_domain_409_response.go
+++ b/api/openapi_client/model_domains_update_domain_409_response.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &DomainsUpdateDomain409Response{}
 type DomainsUpdateDomain409Response struct {
 	Status  int     `json:"status"`
 	Title   string  `json:"title"`
-	Details *string `json:"details,omitempty"`
+	Detail  *string `json:"detail,omitempty"`
 	TraceId string  `json:"traceId"`
 }
 
@@ -98,36 +98,36 @@ func (o *DomainsUpdateDomain409Response) SetTitle(v string) {
 	o.Title = v
 }
 
-// GetDetails returns the Details field value if set, zero value otherwise.
-func (o *DomainsUpdateDomain409Response) GetDetails() string {
-	if o == nil || IsNil(o.Details) {
+// GetDetail returns the Detail field value if set, zero value otherwise.
+func (o *DomainsUpdateDomain409Response) GetDetail() string {
+	if o == nil || IsNil(o.Detail) {
 		var ret string
 		return ret
 	}
-	return *o.Details
+	return *o.Detail
 }
 
-// GetDetailsOk returns a tuple with the Details field value if set, nil otherwise
+// GetDetailOk returns a tuple with the Detail field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DomainsUpdateDomain409Response) GetDetailsOk() (*string, bool) {
-	if o == nil || IsNil(o.Details) {
+func (o *DomainsUpdateDomain409Response) GetDetailOk() (*string, bool) {
+	if o == nil || IsNil(o.Detail) {
 		return nil, false
 	}
-	return o.Details, true
+	return o.Detail, true
 }
 
-// HasDetails returns a boolean if a field has been set.
-func (o *DomainsUpdateDomain409Response) HasDetails() bool {
-	if o != nil && !IsNil(o.Details) {
+// HasDetail returns a boolean if a field has been set.
+func (o *DomainsUpdateDomain409Response) HasDetail() bool {
+	if o != nil && !IsNil(o.Detail) {
 		return true
 	}
 
 	return false
 }
 
-// SetDetails gets a reference to the given string and assigns it to the Details field.
-func (o *DomainsUpdateDomain409Response) SetDetails(v string) {
-	o.Details = &v
+// SetDetail gets a reference to the given string and assigns it to the Detail field.
+func (o *DomainsUpdateDomain409Response) SetDetail(v string) {
+	o.Detail = &v
 }
 
 // GetTraceId returns the TraceId field value
@@ -166,8 +166,8 @@ func (o DomainsUpdateDomain409Response) ToMap() (map[string]interface{}, error) 
 	toSerialize := map[string]interface{}{}
 	toSerialize["status"] = o.Status
 	toSerialize["title"] = o.Title
-	if !IsNil(o.Details) {
-		toSerialize["details"] = o.Details
+	if !IsNil(o.Detail) {
+		toSerialize["detail"] = o.Detail
 	}
 	toSerialize["traceId"] = o.TraceId
 	return toSerialize, nil
@@ -200,7 +200,7 @@ func (o *DomainsUpdateDomain409Response) UnmarshalJSON(data []byte) (err error) 
 	varDomainsUpdateDomain409Response := _DomainsUpdateDomain409Response{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varDomainsUpdateDomain409Response)
 
 	if err != nil {

--- a/api/openapi_client/model_metadata_get_datacenters_200_response_inner.go
+++ b/api/openapi_client/model_metadata_get_datacenters_200_response_inner.go
@@ -22,10 +22,10 @@ var _ MappedNullable = &MetadataGetDatacenters200ResponseInner{}
 
 // MetadataGetDatacenters200ResponseInner struct for MetadataGetDatacenters200ResponseInner
 type MetadataGetDatacenters200ResponseInner struct {
-	Id          float32 `json:"id"`
-	Name        string  `json:"name"`
-	City        string  `json:"city"`
-	CountryCode string  `json:"countryCode"`
+	Id          int    `json:"id"`
+	Name        string `json:"name"`
+	City        string `json:"city"`
+	CountryCode string `json:"countryCode"`
 }
 
 type _MetadataGetDatacenters200ResponseInner MetadataGetDatacenters200ResponseInner
@@ -34,7 +34,7 @@ type _MetadataGetDatacenters200ResponseInner MetadataGetDatacenters200ResponseIn
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewMetadataGetDatacenters200ResponseInner(id float32, name string, city string, countryCode string) *MetadataGetDatacenters200ResponseInner {
+func NewMetadataGetDatacenters200ResponseInner(id int, name string, city string, countryCode string) *MetadataGetDatacenters200ResponseInner {
 	this := MetadataGetDatacenters200ResponseInner{}
 	this.Id = id
 	this.Name = name
@@ -52,9 +52,9 @@ func NewMetadataGetDatacenters200ResponseInnerWithDefaults() *MetadataGetDatacen
 }
 
 // GetId returns the Id field value
-func (o *MetadataGetDatacenters200ResponseInner) GetId() float32 {
+func (o *MetadataGetDatacenters200ResponseInner) GetId() int {
 	if o == nil {
-		var ret float32
+		var ret int
 		return ret
 	}
 
@@ -63,7 +63,7 @@ func (o *MetadataGetDatacenters200ResponseInner) GetId() float32 {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *MetadataGetDatacenters200ResponseInner) GetIdOk() (*float32, bool) {
+func (o *MetadataGetDatacenters200ResponseInner) GetIdOk() (*int, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -71,7 +71,7 @@ func (o *MetadataGetDatacenters200ResponseInner) GetIdOk() (*float32, bool) {
 }
 
 // SetId sets field value
-func (o *MetadataGetDatacenters200ResponseInner) SetId(v float32) {
+func (o *MetadataGetDatacenters200ResponseInner) SetId(v int) {
 	o.Id = v
 }
 
@@ -192,7 +192,7 @@ func (o *MetadataGetDatacenters200ResponseInner) UnmarshalJSON(data []byte) (err
 	varMetadataGetDatacenters200ResponseInner := _MetadataGetDatacenters200ResponseInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMetadataGetDatacenters200ResponseInner)
 
 	if err != nil {

--- a/api/openapi_client/model_metadata_get_workspace_plans_200_response_inner.go
+++ b/api/openapi_client/model_metadata_get_workspace_plans_200_response_inner.go
@@ -22,7 +22,7 @@ var _ MappedNullable = &MetadataGetWorkspacePlans200ResponseInner{}
 
 // MetadataGetWorkspacePlans200ResponseInner struct for MetadataGetWorkspacePlans200ResponseInner
 type MetadataGetWorkspacePlans200ResponseInner struct {
-	Id              float32                                                  `json:"id"`
+	Id              int                                                      `json:"id"`
 	PriceUsd        float32                                                  `json:"priceUsd"`
 	Title           string                                                   `json:"title"`
 	Deprecated      bool                                                     `json:"deprecated"`
@@ -36,7 +36,7 @@ type _MetadataGetWorkspacePlans200ResponseInner MetadataGetWorkspacePlans200Resp
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewMetadataGetWorkspacePlans200ResponseInner(id float32, priceUsd float32, title string, deprecated bool, characteristics MetadataGetWorkspacePlans200ResponseInnerCharacteristics, maxReplicas int) *MetadataGetWorkspacePlans200ResponseInner {
+func NewMetadataGetWorkspacePlans200ResponseInner(id int, priceUsd float32, title string, deprecated bool, characteristics MetadataGetWorkspacePlans200ResponseInnerCharacteristics, maxReplicas int) *MetadataGetWorkspacePlans200ResponseInner {
 	this := MetadataGetWorkspacePlans200ResponseInner{}
 	this.Id = id
 	this.PriceUsd = priceUsd
@@ -56,9 +56,9 @@ func NewMetadataGetWorkspacePlans200ResponseInnerWithDefaults() *MetadataGetWork
 }
 
 // GetId returns the Id field value
-func (o *MetadataGetWorkspacePlans200ResponseInner) GetId() float32 {
+func (o *MetadataGetWorkspacePlans200ResponseInner) GetId() int {
 	if o == nil {
-		var ret float32
+		var ret int
 		return ret
 	}
 
@@ -67,7 +67,7 @@ func (o *MetadataGetWorkspacePlans200ResponseInner) GetId() float32 {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *MetadataGetWorkspacePlans200ResponseInner) GetIdOk() (*float32, bool) {
+func (o *MetadataGetWorkspacePlans200ResponseInner) GetIdOk() (*int, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -75,7 +75,7 @@ func (o *MetadataGetWorkspacePlans200ResponseInner) GetIdOk() (*float32, bool) {
 }
 
 // SetId sets field value
-func (o *MetadataGetWorkspacePlans200ResponseInner) SetId(v float32) {
+func (o *MetadataGetWorkspacePlans200ResponseInner) SetId(v int) {
 	o.Id = v
 }
 
@@ -248,7 +248,7 @@ func (o *MetadataGetWorkspacePlans200ResponseInner) UnmarshalJSON(data []byte) (
 	varMetadataGetWorkspacePlans200ResponseInner := _MetadataGetWorkspacePlans200ResponseInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMetadataGetWorkspacePlans200ResponseInner)
 
 	if err != nil {

--- a/api/openapi_client/model_metadata_get_workspace_plans_200_response_inner_characteristics.go
+++ b/api/openapi_client/model_metadata_get_workspace_plans_200_response_inner_characteristics.go
@@ -276,7 +276,7 @@ func (o *MetadataGetWorkspacePlans200ResponseInnerCharacteristics) UnmarshalJSON
 	varMetadataGetWorkspacePlans200ResponseInnerCharacteristics := _MetadataGetWorkspacePlans200ResponseInnerCharacteristics{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMetadataGetWorkspacePlans200ResponseInnerCharacteristics)
 
 	if err != nil {

--- a/api/openapi_client/model_teams_create_team_request.go
+++ b/api/openapi_client/model_teams_create_team_request.go
@@ -136,7 +136,7 @@ func (o *TeamsCreateTeamRequest) UnmarshalJSON(data []byte) (err error) {
 	varTeamsCreateTeamRequest := _TeamsCreateTeamRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTeamsCreateTeamRequest)
 
 	if err != nil {

--- a/api/openapi_client/model_teams_get_team_200_response.go
+++ b/api/openapi_client/model_teams_get_team_200_response.go
@@ -341,7 +341,7 @@ func (o *TeamsGetTeam200Response) UnmarshalJSON(data []byte) (err error) {
 	varTeamsGetTeam200Response := _TeamsGetTeam200Response{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTeamsGetTeam200Response)
 
 	if err != nil {

--- a/api/openapi_client/model_teams_list_teams_200_response_inner.go
+++ b/api/openapi_client/model_teams_list_teams_200_response_inner.go
@@ -370,7 +370,7 @@ func (o *TeamsListTeams200ResponseInner) UnmarshalJSON(data []byte) (err error) 
 	varTeamsListTeams200ResponseInner := _TeamsListTeams200ResponseInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTeamsListTeams200ResponseInner)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_create_workspace_request.go
+++ b/api/openapi_client/model_workspaces_create_workspace_request.go
@@ -26,11 +26,11 @@ type WorkspacesCreateWorkspaceRequest struct {
 	Name              string  `json:"name"`
 	PlanId            int     `json:"planId"`
 	IsPrivateRepo     bool    `json:"isPrivateRepo"`
+	Replicas          int     `json:"replicas"`
 	GitUrl            *string `json:"gitUrl,omitempty"`
 	InitialBranch     *string `json:"initialBranch,omitempty"`
 	SourceWorkspaceId *int    `json:"sourceWorkspaceId,omitempty"`
 	WelcomeMessage    *string `json:"welcomeMessage,omitempty"`
-	Replicas          int     `json:"replicas"`
 	VpnConfig         *string `json:"vpnConfig,omitempty"`
 }
 
@@ -152,6 +152,30 @@ func (o *WorkspacesCreateWorkspaceRequest) GetIsPrivateRepoOk() (*bool, bool) {
 // SetIsPrivateRepo sets field value
 func (o *WorkspacesCreateWorkspaceRequest) SetIsPrivateRepo(v bool) {
 	o.IsPrivateRepo = v
+}
+
+// GetReplicas returns the Replicas field value
+func (o *WorkspacesCreateWorkspaceRequest) GetReplicas() int {
+	if o == nil {
+		var ret int
+		return ret
+	}
+
+	return o.Replicas
+}
+
+// GetReplicasOk returns a tuple with the Replicas field value
+// and a boolean to check if the value has been set.
+func (o *WorkspacesCreateWorkspaceRequest) GetReplicasOk() (*int, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Replicas, true
+}
+
+// SetReplicas sets field value
+func (o *WorkspacesCreateWorkspaceRequest) SetReplicas(v int) {
+	o.Replicas = v
 }
 
 // GetGitUrl returns the GitUrl field value if set, zero value otherwise.
@@ -282,30 +306,6 @@ func (o *WorkspacesCreateWorkspaceRequest) SetWelcomeMessage(v string) {
 	o.WelcomeMessage = &v
 }
 
-// GetReplicas returns the Replicas field value
-func (o *WorkspacesCreateWorkspaceRequest) GetReplicas() int {
-	if o == nil {
-		var ret int
-		return ret
-	}
-
-	return o.Replicas
-}
-
-// GetReplicasOk returns a tuple with the Replicas field value
-// and a boolean to check if the value has been set.
-func (o *WorkspacesCreateWorkspaceRequest) GetReplicasOk() (*int, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.Replicas, true
-}
-
-// SetReplicas sets field value
-func (o *WorkspacesCreateWorkspaceRequest) SetReplicas(v int) {
-	o.Replicas = v
-}
-
 // GetVpnConfig returns the VpnConfig field value if set, zero value otherwise.
 func (o *WorkspacesCreateWorkspaceRequest) GetVpnConfig() string {
 	if o == nil || IsNil(o.VpnConfig) {
@@ -352,6 +352,7 @@ func (o WorkspacesCreateWorkspaceRequest) ToMap() (map[string]interface{}, error
 	toSerialize["name"] = o.Name
 	toSerialize["planId"] = o.PlanId
 	toSerialize["isPrivateRepo"] = o.IsPrivateRepo
+	toSerialize["replicas"] = o.Replicas
 	if !IsNil(o.GitUrl) {
 		toSerialize["gitUrl"] = o.GitUrl
 	}
@@ -364,7 +365,6 @@ func (o WorkspacesCreateWorkspaceRequest) ToMap() (map[string]interface{}, error
 	if !IsNil(o.WelcomeMessage) {
 		toSerialize["welcomeMessage"] = o.WelcomeMessage
 	}
-	toSerialize["replicas"] = o.Replicas
 	if !IsNil(o.VpnConfig) {
 		toSerialize["vpnConfig"] = o.VpnConfig
 	}
@@ -400,7 +400,7 @@ func (o *WorkspacesCreateWorkspaceRequest) UnmarshalJSON(data []byte) (err error
 	varWorkspacesCreateWorkspaceRequest := _WorkspacesCreateWorkspaceRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesCreateWorkspaceRequest)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_execute_command_200_response.go
+++ b/api/openapi_client/model_workspaces_execute_command_200_response.go
@@ -192,7 +192,7 @@ func (o *WorkspacesExecuteCommand200Response) UnmarshalJSON(data []byte) (err er
 	varWorkspacesExecuteCommand200Response := _WorkspacesExecuteCommand200Response{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesExecuteCommand200Response)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_execute_command_request.go
+++ b/api/openapi_client/model_workspaces_execute_command_request.go
@@ -180,7 +180,7 @@ func (o *WorkspacesExecuteCommandRequest) UnmarshalJSON(data []byte) (err error)
 	varWorkspacesExecuteCommandRequest := _WorkspacesExecuteCommandRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesExecuteCommandRequest)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_get_workspace_200_response.go
+++ b/api/openapi_client/model_workspaces_get_workspace_200_response.go
@@ -22,18 +22,18 @@ var _ MappedNullable = &WorkspacesGetWorkspace200Response{}
 
 // WorkspacesGetWorkspace200Response struct for WorkspacesGetWorkspace200Response
 type WorkspacesGetWorkspace200Response struct {
-	Id                int            `json:"id"`
-	DataCenterId      float32        `json:"dataCenterId"`
-	UserId            int            `json:"userId"`
 	TeamId            int            `json:"teamId"`
 	Name              string         `json:"name"`
-	GitUrl            NullableString `json:"gitUrl"`
+	PlanId            int            `json:"planId"`
 	IsPrivateRepo     bool           `json:"isPrivateRepo"`
-	WelcomeMessage    NullableString `json:"welcomeMessage"`
+	Replicas          int            `json:"replicas"`
+	Id                int            `json:"id"`
+	DataCenterId      int            `json:"dataCenterId"`
+	UserId            int            `json:"userId"`
+	GitUrl            NullableString `json:"gitUrl"`
 	InitialBranch     NullableString `json:"initialBranch"`
 	SourceWorkspaceId NullableInt    `json:"sourceWorkspaceId"`
-	PlanId            int            `json:"planId"`
-	Replicas          int            `json:"replicas"`
+	WelcomeMessage    NullableString `json:"welcomeMessage"`
 	VpnConfig         NullableString `json:"vpnConfig"`
 }
 
@@ -43,20 +43,20 @@ type _WorkspacesGetWorkspace200Response WorkspacesGetWorkspace200Response
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewWorkspacesGetWorkspace200Response(id int, dataCenterId float32, userId int, teamId int, name string, gitUrl NullableString, isPrivateRepo bool, welcomeMessage NullableString, initialBranch NullableString, sourceWorkspaceId NullableInt, planId int, replicas int, vpnConfig NullableString) *WorkspacesGetWorkspace200Response {
+func NewWorkspacesGetWorkspace200Response(teamId int, name string, planId int, isPrivateRepo bool, replicas int, id int, dataCenterId int, userId int, gitUrl NullableString, initialBranch NullableString, sourceWorkspaceId NullableInt, welcomeMessage NullableString, vpnConfig NullableString) *WorkspacesGetWorkspace200Response {
 	this := WorkspacesGetWorkspace200Response{}
+	this.TeamId = teamId
+	this.Name = name
+	this.PlanId = planId
+	this.IsPrivateRepo = isPrivateRepo
+	this.Replicas = replicas
 	this.Id = id
 	this.DataCenterId = dataCenterId
 	this.UserId = userId
-	this.TeamId = teamId
-	this.Name = name
 	this.GitUrl = gitUrl
-	this.IsPrivateRepo = isPrivateRepo
-	this.WelcomeMessage = welcomeMessage
 	this.InitialBranch = initialBranch
 	this.SourceWorkspaceId = sourceWorkspaceId
-	this.PlanId = planId
-	this.Replicas = replicas
+	this.WelcomeMessage = welcomeMessage
 	this.VpnConfig = vpnConfig
 	return &this
 }
@@ -67,78 +67,6 @@ func NewWorkspacesGetWorkspace200Response(id int, dataCenterId float32, userId i
 func NewWorkspacesGetWorkspace200ResponseWithDefaults() *WorkspacesGetWorkspace200Response {
 	this := WorkspacesGetWorkspace200Response{}
 	return &this
-}
-
-// GetId returns the Id field value
-func (o *WorkspacesGetWorkspace200Response) GetId() int {
-	if o == nil {
-		var ret int
-		return ret
-	}
-
-	return o.Id
-}
-
-// GetIdOk returns a tuple with the Id field value
-// and a boolean to check if the value has been set.
-func (o *WorkspacesGetWorkspace200Response) GetIdOk() (*int, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.Id, true
-}
-
-// SetId sets field value
-func (o *WorkspacesGetWorkspace200Response) SetId(v int) {
-	o.Id = v
-}
-
-// GetDataCenterId returns the DataCenterId field value
-func (o *WorkspacesGetWorkspace200Response) GetDataCenterId() float32 {
-	if o == nil {
-		var ret float32
-		return ret
-	}
-
-	return o.DataCenterId
-}
-
-// GetDataCenterIdOk returns a tuple with the DataCenterId field value
-// and a boolean to check if the value has been set.
-func (o *WorkspacesGetWorkspace200Response) GetDataCenterIdOk() (*float32, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.DataCenterId, true
-}
-
-// SetDataCenterId sets field value
-func (o *WorkspacesGetWorkspace200Response) SetDataCenterId(v float32) {
-	o.DataCenterId = v
-}
-
-// GetUserId returns the UserId field value
-func (o *WorkspacesGetWorkspace200Response) GetUserId() int {
-	if o == nil {
-		var ret int
-		return ret
-	}
-
-	return o.UserId
-}
-
-// GetUserIdOk returns a tuple with the UserId field value
-// and a boolean to check if the value has been set.
-func (o *WorkspacesGetWorkspace200Response) GetUserIdOk() (*int, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.UserId, true
-}
-
-// SetUserId sets field value
-func (o *WorkspacesGetWorkspace200Response) SetUserId(v int) {
-	o.UserId = v
 }
 
 // GetTeamId returns the TeamId field value
@@ -189,30 +117,28 @@ func (o *WorkspacesGetWorkspace200Response) SetName(v string) {
 	o.Name = v
 }
 
-// GetGitUrl returns the GitUrl field value
-// If the value is explicit nil, the zero value for string will be returned
-func (o *WorkspacesGetWorkspace200Response) GetGitUrl() string {
-	if o == nil || o.GitUrl.Get() == nil {
-		var ret string
+// GetPlanId returns the PlanId field value
+func (o *WorkspacesGetWorkspace200Response) GetPlanId() int {
+	if o == nil {
+		var ret int
 		return ret
 	}
 
-	return *o.GitUrl.Get()
+	return o.PlanId
 }
 
-// GetGitUrlOk returns a tuple with the GitUrl field value
+// GetPlanIdOk returns a tuple with the PlanId field value
 // and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *WorkspacesGetWorkspace200Response) GetGitUrlOk() (*string, bool) {
+func (o *WorkspacesGetWorkspace200Response) GetPlanIdOk() (*int, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return o.GitUrl.Get(), o.GitUrl.IsSet()
+	return &o.PlanId, true
 }
 
-// SetGitUrl sets field value
-func (o *WorkspacesGetWorkspace200Response) SetGitUrl(v string) {
-	o.GitUrl.Set(&v)
+// SetPlanId sets field value
+func (o *WorkspacesGetWorkspace200Response) SetPlanId(v int) {
+	o.PlanId = v
 }
 
 // GetIsPrivateRepo returns the IsPrivateRepo field value
@@ -239,30 +165,126 @@ func (o *WorkspacesGetWorkspace200Response) SetIsPrivateRepo(v bool) {
 	o.IsPrivateRepo = v
 }
 
-// GetWelcomeMessage returns the WelcomeMessage field value
+// GetReplicas returns the Replicas field value
+func (o *WorkspacesGetWorkspace200Response) GetReplicas() int {
+	if o == nil {
+		var ret int
+		return ret
+	}
+
+	return o.Replicas
+}
+
+// GetReplicasOk returns a tuple with the Replicas field value
+// and a boolean to check if the value has been set.
+func (o *WorkspacesGetWorkspace200Response) GetReplicasOk() (*int, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Replicas, true
+}
+
+// SetReplicas sets field value
+func (o *WorkspacesGetWorkspace200Response) SetReplicas(v int) {
+	o.Replicas = v
+}
+
+// GetId returns the Id field value
+func (o *WorkspacesGetWorkspace200Response) GetId() int {
+	if o == nil {
+		var ret int
+		return ret
+	}
+
+	return o.Id
+}
+
+// GetIdOk returns a tuple with the Id field value
+// and a boolean to check if the value has been set.
+func (o *WorkspacesGetWorkspace200Response) GetIdOk() (*int, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Id, true
+}
+
+// SetId sets field value
+func (o *WorkspacesGetWorkspace200Response) SetId(v int) {
+	o.Id = v
+}
+
+// GetDataCenterId returns the DataCenterId field value
+func (o *WorkspacesGetWorkspace200Response) GetDataCenterId() int {
+	if o == nil {
+		var ret int
+		return ret
+	}
+
+	return o.DataCenterId
+}
+
+// GetDataCenterIdOk returns a tuple with the DataCenterId field value
+// and a boolean to check if the value has been set.
+func (o *WorkspacesGetWorkspace200Response) GetDataCenterIdOk() (*int, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.DataCenterId, true
+}
+
+// SetDataCenterId sets field value
+func (o *WorkspacesGetWorkspace200Response) SetDataCenterId(v int) {
+	o.DataCenterId = v
+}
+
+// GetUserId returns the UserId field value
+func (o *WorkspacesGetWorkspace200Response) GetUserId() int {
+	if o == nil {
+		var ret int
+		return ret
+	}
+
+	return o.UserId
+}
+
+// GetUserIdOk returns a tuple with the UserId field value
+// and a boolean to check if the value has been set.
+func (o *WorkspacesGetWorkspace200Response) GetUserIdOk() (*int, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.UserId, true
+}
+
+// SetUserId sets field value
+func (o *WorkspacesGetWorkspace200Response) SetUserId(v int) {
+	o.UserId = v
+}
+
+// GetGitUrl returns the GitUrl field value
 // If the value is explicit nil, the zero value for string will be returned
-func (o *WorkspacesGetWorkspace200Response) GetWelcomeMessage() string {
-	if o == nil || o.WelcomeMessage.Get() == nil {
+func (o *WorkspacesGetWorkspace200Response) GetGitUrl() string {
+	if o == nil || o.GitUrl.Get() == nil {
 		var ret string
 		return ret
 	}
 
-	return *o.WelcomeMessage.Get()
+	return *o.GitUrl.Get()
 }
 
-// GetWelcomeMessageOk returns a tuple with the WelcomeMessage field value
+// GetGitUrlOk returns a tuple with the GitUrl field value
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *WorkspacesGetWorkspace200Response) GetWelcomeMessageOk() (*string, bool) {
+func (o *WorkspacesGetWorkspace200Response) GetGitUrlOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return o.WelcomeMessage.Get(), o.WelcomeMessage.IsSet()
+	return o.GitUrl.Get(), o.GitUrl.IsSet()
 }
 
-// SetWelcomeMessage sets field value
-func (o *WorkspacesGetWorkspace200Response) SetWelcomeMessage(v string) {
-	o.WelcomeMessage.Set(&v)
+// SetGitUrl sets field value
+func (o *WorkspacesGetWorkspace200Response) SetGitUrl(v string) {
+	o.GitUrl.Set(&v)
 }
 
 // GetInitialBranch returns the InitialBranch field value
@@ -317,52 +339,30 @@ func (o *WorkspacesGetWorkspace200Response) SetSourceWorkspaceId(v int) {
 	o.SourceWorkspaceId.Set(&v)
 }
 
-// GetPlanId returns the PlanId field value
-func (o *WorkspacesGetWorkspace200Response) GetPlanId() int {
-	if o == nil {
-		var ret int
+// GetWelcomeMessage returns the WelcomeMessage field value
+// If the value is explicit nil, the zero value for string will be returned
+func (o *WorkspacesGetWorkspace200Response) GetWelcomeMessage() string {
+	if o == nil || o.WelcomeMessage.Get() == nil {
+		var ret string
 		return ret
 	}
 
-	return o.PlanId
+	return *o.WelcomeMessage.Get()
 }
 
-// GetPlanIdOk returns a tuple with the PlanId field value
+// GetWelcomeMessageOk returns a tuple with the WelcomeMessage field value
 // and a boolean to check if the value has been set.
-func (o *WorkspacesGetWorkspace200Response) GetPlanIdOk() (*int, bool) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *WorkspacesGetWorkspace200Response) GetWelcomeMessageOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.PlanId, true
+	return o.WelcomeMessage.Get(), o.WelcomeMessage.IsSet()
 }
 
-// SetPlanId sets field value
-func (o *WorkspacesGetWorkspace200Response) SetPlanId(v int) {
-	o.PlanId = v
-}
-
-// GetReplicas returns the Replicas field value
-func (o *WorkspacesGetWorkspace200Response) GetReplicas() int {
-	if o == nil {
-		var ret int
-		return ret
-	}
-
-	return o.Replicas
-}
-
-// GetReplicasOk returns a tuple with the Replicas field value
-// and a boolean to check if the value has been set.
-func (o *WorkspacesGetWorkspace200Response) GetReplicasOk() (*int, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.Replicas, true
-}
-
-// SetReplicas sets field value
-func (o *WorkspacesGetWorkspace200Response) SetReplicas(v int) {
-	o.Replicas = v
+// SetWelcomeMessage sets field value
+func (o *WorkspacesGetWorkspace200Response) SetWelcomeMessage(v string) {
+	o.WelcomeMessage.Set(&v)
 }
 
 // GetVpnConfig returns the VpnConfig field value
@@ -401,18 +401,18 @@ func (o WorkspacesGetWorkspace200Response) MarshalJSON() ([]byte, error) {
 
 func (o WorkspacesGetWorkspace200Response) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	toSerialize["teamId"] = o.TeamId
+	toSerialize["name"] = o.Name
+	toSerialize["planId"] = o.PlanId
+	toSerialize["isPrivateRepo"] = o.IsPrivateRepo
+	toSerialize["replicas"] = o.Replicas
 	toSerialize["id"] = o.Id
 	toSerialize["dataCenterId"] = o.DataCenterId
 	toSerialize["userId"] = o.UserId
-	toSerialize["teamId"] = o.TeamId
-	toSerialize["name"] = o.Name
 	toSerialize["gitUrl"] = o.GitUrl.Get()
-	toSerialize["isPrivateRepo"] = o.IsPrivateRepo
-	toSerialize["welcomeMessage"] = o.WelcomeMessage.Get()
 	toSerialize["initialBranch"] = o.InitialBranch.Get()
 	toSerialize["sourceWorkspaceId"] = o.SourceWorkspaceId.Get()
-	toSerialize["planId"] = o.PlanId
-	toSerialize["replicas"] = o.Replicas
+	toSerialize["welcomeMessage"] = o.WelcomeMessage.Get()
 	toSerialize["vpnConfig"] = o.VpnConfig.Get()
 	return toSerialize, nil
 }
@@ -422,18 +422,18 @@ func (o *WorkspacesGetWorkspace200Response) UnmarshalJSON(data []byte) (err erro
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
+		"teamId",
+		"name",
+		"planId",
+		"isPrivateRepo",
+		"replicas",
 		"id",
 		"dataCenterId",
 		"userId",
-		"teamId",
-		"name",
 		"gitUrl",
-		"isPrivateRepo",
-		"welcomeMessage",
 		"initialBranch",
 		"sourceWorkspaceId",
-		"planId",
-		"replicas",
+		"welcomeMessage",
 		"vpnConfig",
 	}
 
@@ -454,7 +454,7 @@ func (o *WorkspacesGetWorkspace200Response) UnmarshalJSON(data []byte) (err erro
 	varWorkspacesGetWorkspace200Response := _WorkspacesGetWorkspace200Response{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesGetWorkspace200Response)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_get_workspace_status_200_response.go
+++ b/api/openapi_client/model_workspaces_get_workspace_status_200_response.go
@@ -108,7 +108,7 @@ func (o *WorkspacesGetWorkspaceStatus200Response) UnmarshalJSON(data []byte) (er
 	varWorkspacesGetWorkspaceStatus200Response := _WorkspacesGetWorkspaceStatus200Response{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesGetWorkspaceStatus200Response)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_git_head_200_response.go
+++ b/api/openapi_client/model_workspaces_git_head_200_response.go
@@ -108,7 +108,7 @@ func (o *WorkspacesGitHead200Response) UnmarshalJSON(data []byte) (err error) {
 	varWorkspacesGitHead200Response := _WorkspacesGitHead200Response{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesGitHead200Response)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_list_env_vars_200_response_inner.go
+++ b/api/openapi_client/model_workspaces_list_env_vars_200_response_inner.go
@@ -136,7 +136,7 @@ func (o *WorkspacesListEnvVars200ResponseInner) UnmarshalJSON(data []byte) (err 
 	varWorkspacesListEnvVars200ResponseInner := _WorkspacesListEnvVars200ResponseInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesListEnvVars200ResponseInner)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_logs_get_response.go
+++ b/api/openapi_client/model_workspaces_logs_get_response.go
@@ -136,7 +136,7 @@ func (o *WorkspacesLogsGetResponse) UnmarshalJSON(data []byte) (err error) {
 	varWorkspacesLogsGetResponse := _WorkspacesLogsGetResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesLogsGetResponse)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_logs_get_response_data_inner.go
+++ b/api/openapi_client/model_workspaces_logs_get_response_data_inner.go
@@ -165,7 +165,7 @@ func (o *WorkspacesLogsGetResponseDataInner) UnmarshalJSON(data []byte) (err err
 	varWorkspacesLogsGetResponseDataInner := _WorkspacesLogsGetResponseDataInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesLogsGetResponseDataInner)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_pipeline_status_200_response_inner.go
+++ b/api/openapi_client/model_workspaces_pipeline_status_200_response_inner.go
@@ -265,7 +265,7 @@ func (o *WorkspacesPipelineStatus200ResponseInner) UnmarshalJSON(data []byte) (e
 	varWorkspacesPipelineStatus200ResponseInner := _WorkspacesPipelineStatus200ResponseInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesPipelineStatus200ResponseInner)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_pipeline_status_200_response_inner_steps_inner.go
+++ b/api/openapi_client/model_workspaces_pipeline_status_200_response_inner_steps_inner.go
@@ -181,7 +181,7 @@ func (o *WorkspacesPipelineStatus200ResponseInnerStepsInner) UnmarshalJSON(data 
 	varWorkspacesPipelineStatus200ResponseInnerStepsInner := _WorkspacesPipelineStatus200ResponseInnerStepsInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesPipelineStatus200ResponseInnerStepsInner)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_replica_logs_get_response.go
+++ b/api/openapi_client/model_workspaces_replica_logs_get_response.go
@@ -136,7 +136,7 @@ func (o *WorkspacesReplicaLogsGetResponse) UnmarshalJSON(data []byte) (err error
 	varWorkspacesReplicaLogsGetResponse := _WorkspacesReplicaLogsGetResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesReplicaLogsGetResponse)
 
 	if err != nil {

--- a/api/openapi_client/model_workspaces_server_logs_get_response.go
+++ b/api/openapi_client/model_workspaces_server_logs_get_response.go
@@ -136,7 +136,7 @@ func (o *WorkspacesServerLogsGetResponse) UnmarshalJSON(data []byte) (err error)
 	varWorkspacesServerLogsGetResponse := _WorkspacesServerLogsGetResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
+	//decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varWorkspacesServerLogsGetResponse)
 
 	if err != nil {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -22,11 +22,11 @@ type Client interface {
 func NewClient(opts GlobalOptions) (Client, error) {
 	token, err := cs.GetApiToken()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get API token: %e", err)
+		return nil, fmt.Errorf("failed to get API token: %w", err)
 	}
 	apiUrl, err := url.Parse(opts.GetApiUrl())
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL '%s': %e", opts.GetApiUrl(), err)
+		return nil, fmt.Errorf("failed to parse URL '%s': %w", opts.GetApiUrl(), err)
 	}
 	client := api.NewClient(context.Background(), api.Configuration{
 		BaseUrl: apiUrl,

--- a/cmd/list-teams.go
+++ b/cmd/list-teams.go
@@ -39,12 +39,12 @@ $ cs list teams
 func (l *ListTeamsCmd) RunE(_ *cobra.Command, args []string) (err error) {
 	client, err := NewClient(l.opts)
 	if err != nil {
-		return fmt.Errorf("failed to create Codesphere client: %e", err)
+		return fmt.Errorf("failed to create Codesphere client: %w", err)
 	}
 
 	teams, err := client.ListTeams()
 	if err != nil {
-		return fmt.Errorf("failed to list teams: %e", err)
+		return fmt.Errorf("failed to list teams: %w", err)
 	}
 
 	t := out.GetTableWriter()

--- a/cmd/list-workspaces.go
+++ b/cmd/list-workspaces.go
@@ -49,12 +49,12 @@ func (l *ListWorkspacesCmd) parseLogCmdFlags() {
 func (l *ListWorkspacesCmd) RunE(_ *cobra.Command, args []string) (err error) {
 	client, err := NewClient(l.Opts.GlobalOptions)
 	if err != nil {
-		return fmt.Errorf("failed to create Codesphere client: %e", err)
+		return fmt.Errorf("failed to create Codesphere client: %w", err)
 	}
 
 	workspaces, err := l.ListWorkspaces(client)
 	if err != nil {
-		return fmt.Errorf("failed to list workspaces: %e", err)
+		return fmt.Errorf("failed to list workspaces: %w", err)
 	}
 
 	t := out.GetTableWriter()
@@ -74,13 +74,13 @@ func (l *ListWorkspacesCmd) RunE(_ *cobra.Command, args []string) (err error) {
 func (l *ListWorkspacesCmd) ListWorkspaces(client Client) ([]api.Workspace, error) {
 	teams, err := l.getTeamIds(client)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get teams: %e", err)
+		return nil, fmt.Errorf("failed to get teams: %w", err)
 	}
 	workspaces := []api.Workspace{}
 	for _, team := range teams {
 		teamWorkspaces, err := client.ListWorkspaces(team)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list workspaces: %e", err)
+			return nil, fmt.Errorf("failed to list workspaces: %w", err)
 		}
 		workspaces = append(workspaces, teamWorkspaces...)
 	}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -94,7 +94,7 @@ func (l *LogCmd) RunE(_ *cobra.Command, args []string) (err error) {
 	if *l.scope.workspaceId == 0 {
 		*l.scope.workspaceId, err = strconv.Atoi(os.Getenv("CS_WORKSPACE_ID"))
 		if err != nil {
-			return fmt.Errorf("failed to read env var: %e", err)
+			return fmt.Errorf("failed to read env var: %w", err)
 		}
 		if *l.scope.workspaceId == 0 {
 			return errors.New("workspace ID required, but not provided")
@@ -117,7 +117,7 @@ func (l *LogCmd) RunE(_ *cobra.Command, args []string) (err error) {
 
 	err = l.printAllLogs()
 	if err != nil {
-		return fmt.Errorf("failed to print logs: %e", err)
+		return fmt.Errorf("failed to print logs: %w", err)
 	}
 
 	return nil
@@ -128,7 +128,7 @@ func (l *LogCmd) printAllLogs() error {
 
 	replicas, err := cs.GetPipelineStatus(*l.scope.workspaceId, "run")
 	if err != nil {
-		return fmt.Errorf("failed to get pipeline status: %e", err)
+		return fmt.Errorf("failed to get pipeline status: %w", err)
 	}
 
 	var wg sync.WaitGroup
@@ -143,7 +143,7 @@ func (l *LogCmd) printAllLogs() error {
 				prefix := fmt.Sprintf("|%-10s|%s", replica.Server, replica.Replica[len(replica.Replica)-11:])
 				err = l.printLogsOfReplica(prefix)
 				if err != nil {
-					fmt.Printf("Error printling logs: %e\n", err)
+					fmt.Printf("Error printling logs: %s\n", err.Error())
 				}
 			}()
 		}
@@ -189,12 +189,12 @@ func printLogsOfEndpoint(prefix string, endpoint string) error {
 	req.Header.Set("Accept", "text/event-stream")
 	err = cs.SetAuthoriziationHeader(req)
 	if err != nil {
-		return fmt.Errorf("failed to set header: %e", err)
+		return fmt.Errorf("failed to set header: %w", err)
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to request logs: %e", err)
+		return fmt.Errorf("failed to request logs: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -251,7 +251,7 @@ func printLogsOfEndpoint(prefix string, endpoint string) error {
 			var errRes ErrResponse
 			err = json.Unmarshal([]byte(sse.data), &errRes)
 			if err != nil {
-				return fmt.Errorf("error reading error json: %e", err)
+				return fmt.Errorf("error reading error json: %w", err)
 			}
 			return fmt.Errorf(
 				"server responded with error: %d %s: %s",

--- a/openapi-template/model_simple.mustache
+++ b/openapi-template/model_simple.mustache
@@ -1,0 +1,572 @@
+// checks if the {{classname}} type satisfies the MappedNullable interface at compile time
+var _ MappedNullable = &{{classname}}{}
+
+// {{classname}} {{{description}}}{{^description}}struct for {{{classname}}}{{/description}}
+type {{classname}} struct {
+{{#parentModel.name}}
+{{^isArray}}
+	{{{parentModel.classname}}}
+{{/isArray}}
+{{#isArray}}
+	Items {{{parentModel.classname}}}
+{{/isArray}}
+{{/parentModel.name}}
+{{#vars}}
+{{^-first}}
+{{/-first}}
+{{#description}}
+	// {{{.}}}
+{{/description}}
+{{#deprecated}}
+	// Deprecated
+{{/deprecated}}
+	{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}}{{{vendorExtensions.x-go-datatag}}}
+{{/vars}}
+{{#isAdditionalPropertiesTrue}}
+	AdditionalProperties map[string]interface{}
+{{/isAdditionalPropertiesTrue}}
+}
+
+{{#isAdditionalPropertiesTrue}}
+type _{{{classname}}} {{{classname}}}
+
+{{/isAdditionalPropertiesTrue}}
+{{^isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+type _{{{classname}}} {{{classname}}}
+
+{{/hasRequired}}
+{{/isAdditionalPropertiesTrue}}
+// New{{classname}} instantiates a new {{classname}} object
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed
+func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}}, {{/-last}}{{/requiredVars}}) *{{classname}} {
+	this := {{classname}}{}
+{{#allVars}}
+{{#required}}
+	this.{{name}} = {{nameInCamelCase}}
+{{/required}}
+{{^required}}
+{{#defaultValue}}
+{{^vendorExtensions.x-golang-is-container}}
+{{^isReadOnly}}
+{{#isNullable}}
+	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+{{/isNullable}}
+{{^isNullable}}
+	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	this.{{name}} = &{{nameInCamelCase}}
+{{/isNullable}}
+{{/isReadOnly}}
+{{/vendorExtensions.x-golang-is-container}}
+{{/defaultValue}}
+{{/required}}
+{{/allVars}}
+	return &this
+}
+
+// New{{classname}}WithDefaults instantiates a new {{classname}} object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func New{{classname}}WithDefaults() *{{classname}} {
+	this := {{classname}}{}
+{{#vars}}
+{{#defaultValue}}
+{{^vendorExtensions.x-golang-is-container}}
+{{^isReadOnly}}
+{{#isNullable}}
+{{!we use datatypeWithEnum here, since it will represent the non-nullable name of the datatype, e.g. int64 for NullableInt64}}
+	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+{{/isNullable}}
+{{^isNullable}}
+	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
+{{/isNullable}}
+{{/isReadOnly}}
+{{/vendorExtensions.x-golang-is-container}}
+{{/defaultValue}}
+{{/vars}}
+	return &this
+}
+
+{{#vars}}
+{{#required}}
+// Get{{name}} returns the {{name}} field value
+{{#isNullable}}
+// If the value is explicit nil, the zero value for {{vendorExtensions.x-go-base-type}} will be returned
+{{/isNullable}}
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+	if o == nil{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		var ret {{vendorExtensions.x-go-base-type}}
+		return ret
+	}
+
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return o.{{name}}
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return *o.{{name}}.Get()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return o.{{name}}
+{{/isNullable}}
+}
+
+// Get{{name}}Ok returns a tuple with the {{name}} field value
+// and a boolean to check if the value has been set.
+{{#isNullable}}
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+{{/isNullable}}
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
+	if o == nil{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+{{^isFreeFormObject}}
+		return nil, false
+	{{/isFreeFormObject}}
+	{{#isFreeFormObject}}
+		return {{vendorExtensions.x-go-base-type}}{}, false
+	{{/isFreeFormObject}}
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}o.{{name}}, true
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return o.{{name}}.Get(), o.{{name}}.IsSet()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}o.{{name}}, true
+{{/isNullable}}
+}
+
+// Set{{name}} sets field value
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	o.{{name}} = v
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	o.{{name}}.Set(&v)
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	o.{{name}} = v
+{{/isNullable}}
+}
+
+{{#useDefaultValuesForRequiredVars}}
+{{^isReadOnly}}
+{{#defaultValue}}
+// GetDefault{{{nameInPascalCase}}} returns the default value {{{defaultValue}}} of the {{{name}}} field.
+func (o *{{classname}}) GetDefault{{nameInPascalCase}}() interface{}  {
+	return {{{defaultValue}}}
+}
+{{/defaultValue}}
+{{/isReadOnly}}
+
+{{/useDefaultValuesForRequiredVars}}
+{{/required}}
+{{^required}}
+// Get{{name}} returns the {{name}} field value if set, zero value otherwise{{#isNullable}} (both if not set or set to explicit null){{/isNullable}}.
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+	if o == nil{{^isNullable}} || IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}.Get()){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		var ret {{vendorExtensions.x-go-base-type}}
+		return ret
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return o.{{name}}
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return *o.{{name}}.Get()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return {{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}o.{{name}}
+{{/isNullable}}
+}
+
+// Get{{name}}Ok returns a tuple with the {{name}} field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+{{#isNullable}}
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+{{/isNullable}}
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
+	if o == nil{{^isNullable}} || IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+	{{^isFreeFormObject}}
+		return nil, false
+	{{/isFreeFormObject}}
+	{{#isFreeFormObject}}
+		return {{vendorExtensions.x-go-base-type}}{}, false
+	{{/isFreeFormObject}}
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}o.{{name}}, true
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return o.{{name}}.Get(), o.{{name}}.IsSet()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return o.{{name}}, true
+{{/isNullable}}
+}
+
+// Has{{name}} returns a boolean if a field has been set.
+func (o *{{classname}}) Has{{name}}() bool {
+	if o != nil && {{^isNullable}}!IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}!IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{^vendorExtensions.x-golang-is-container}}o.{{name}}.IsSet(){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		return true
+	}
+
+	return false
+}
+
+// Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	o.{{name}} = v
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	o.{{name}}.Set({{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}v)
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	o.{{name}} = {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}v
+{{/isNullable}}
+}
+{{#isNullable}}
+{{^vendorExtensions.x-golang-is-container}}
+// Set{{name}}Nil sets the value for {{name}} to be an explicit nil
+func (o *{{classname}}) Set{{name}}Nil() {
+	o.{{name}}.Set(nil)
+}
+
+// Unset{{name}} ensures that no value is present for {{name}}, not even an explicit nil
+func (o *{{classname}}) Unset{{name}}() {
+	o.{{name}}.Unset()
+}
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+
+{{/required}}
+{{/vars}}
+{{#vendorExtensions.x-go-generate-marshal-json}}
+func (o {{classname}}) MarshalJSON() ([]byte, error) {
+	toSerialize,err := o.ToMap()
+	if err != nil {
+		return []byte{}, err
+	}
+	return json.Marshal(toSerialize)
+}
+
+{{/vendorExtensions.x-go-generate-marshal-json}}
+func (o {{classname}}) ToMap() (map[string]interface{}, error) {
+	toSerialize := {{#isArray}}make([]interface{}, len(o.Items)){{/isArray}}{{^isArray}}map[string]interface{}{}{{/isArray}}
+	{{#parent}}
+	{{^isMap}}
+	{{^isArray}}
+	serialized{{parent}}, err{{parent}} := json.Marshal(o.{{parent}})
+	if err{{parent}} != nil {
+		return map[string]interface{}{}, err{{parent}}
+	}
+	err{{parent}} = json.Unmarshal([]byte(serialized{{parent}}), &toSerialize)
+	if err{{parent}} != nil {
+		return map[string]interface{}{}, err{{parent}}
+	}
+	{{/isArray}}
+	{{/isMap}}
+	{{#isArray}}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	{{/isArray}}
+	{{/parent}}
+	{{#vars}}
+	{{! if argument is nullable, only serialize it if it is set}}
+	{{#isNullable}}
+	{{#vendorExtensions.x-golang-is-container}}
+	{{! support for container fields is not ideal at this point because of lack of Nullable* types}}
+	if o.{{name}} != nil {
+		toSerialize["{{{baseName}}}"] = o.{{name}}
+	}
+	{{/vendorExtensions.x-golang-is-container}}
+	{{^vendorExtensions.x-golang-is-container}}
+	{{#required}}
+	toSerialize["{{{baseName}}}"] = o.{{name}}.Get()
+	{{/required}}
+	{{^required}}
+	if o.{{name}}.IsSet() {
+		toSerialize["{{{baseName}}}"] = o.{{name}}.Get()
+	}
+	{{/required}}
+	{{/vendorExtensions.x-golang-is-container}}
+	{{/isNullable}}
+	{{! if argument is not nullable, don't set it if it is nil}}
+	{{^isNullable}}
+	{{#required}}
+	{{#useDefaultValuesForRequiredVars}}
+	{{^isReadOnly}}
+	{{#defaultValue}}
+	if _, exists := toSerialize["{{{baseName}}}"]; !exists {
+		toSerialize["{{{baseName}}}"] = o.GetDefault{{nameInPascalCase}}()
+	}
+	{{/defaultValue}}
+	{{/isReadOnly}}
+	{{/useDefaultValuesForRequiredVars}}
+	toSerialize["{{{baseName}}}"] = o.{{name}}
+	{{/required}}
+	{{^required}}
+	if !IsNil(o.{{name}}) {
+		toSerialize["{{{baseName}}}"] = o.{{name}}
+	}
+	{{/required}}
+	{{/isNullable}}
+	{{/vars}}
+	{{#isAdditionalPropertiesTrue}}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
+	{{/isAdditionalPropertiesTrue}}
+	return toSerialize, nil
+}
+
+{{#vendorExtensions.x-go-generate-unmarshal-json}}
+{{#isAdditionalPropertiesTrue}}
+func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
+{{/isAdditionalPropertiesTrue}}
+{{^isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
+{{/hasRequired}}
+{{/isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+	// This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+{{#requiredVars}}
+		"{{baseName}}",
+{{/requiredVars}}
+	}
+
+{{#useDefaultValuesForRequiredVars}}
+	// defaultValueFuncMap captures the default values for required properties.
+	// These values are used when required properties are missing from the payload.
+	defaultValueFuncMap := map[string]func() interface{} {
+{{#requiredVars}}
+{{#defaultValue}}
+{{^isReadOnly}}
+		"{{baseName}}": o.GetDefault{{nameInPascalCase}},
+{{/isReadOnly}}
+{{/defaultValue}}
+{{/requiredVars}}
+	}
+	var defaultValueApplied bool
+{{/useDefaultValuesForRequiredVars}}
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(data, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		{{#useDefaultValuesForRequiredVars}}
+		if value, exists := allProperties[requiredProperty]; !exists || value == "" {
+			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
+				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
+				defaultValueApplied = true
+			}
+		}
+		if value, exists := allProperties[requiredProperty]; !exists || value == ""{
+		{{/useDefaultValuesForRequiredVars}}
+		{{^useDefaultValuesForRequiredVars}}
+		if _, exists := allProperties[requiredProperty]; !exists {
+		{{/useDefaultValuesForRequiredVars}}
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	{{#useDefaultValuesForRequiredVars}}
+	if defaultValueApplied {
+		data, err = json.Marshal(allProperties)
+		if err != nil{
+			return err
+		}
+	}
+	{{/useDefaultValuesForRequiredVars}}
+{{/hasRequired}}
+{{#isAdditionalPropertiesTrue}}
+{{#parent}}
+{{^isMap}}
+	type {{classname}}WithoutEmbeddedStruct struct {
+	{{#vars}}
+	{{^-first}}
+	{{/-first}}
+	{{#description}}
+		// {{{.}}}
+	{{/description}}
+	{{#deprecated}}
+		// Deprecated
+	{{/deprecated}}
+		{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}}{{{vendorExtensions.x-go-datatag}}}
+	{{/vars}}
+	}
+
+	var{{{classname}}}WithoutEmbeddedStruct := {{{classname}}}WithoutEmbeddedStruct{}
+
+	err = json.Unmarshal(data, &var{{{classname}}}WithoutEmbeddedStruct)
+	if err == nil {
+		var{{{classname}}} := _{{{classname}}}{}
+		{{#vars}}
+		var{{{classname}}}.{{{name}}} = var{{{classname}}}WithoutEmbeddedStruct.{{{name}}}
+		{{/vars}}
+		*o = {{{classname}}}(var{{{classname}}})
+	} else {
+		return err
+	}
+
+	var{{{classname}}} := _{{{classname}}}{}
+
+	err = json.Unmarshal(data, &var{{{classname}}})
+	if err == nil {
+		o.{{{parent}}} = var{{{classname}}}.{{{parent}}}
+	} else {
+		return err
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+
+		// remove fields from embedded structs
+		reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
+		for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
+			t := reflect{{{parent}}}.Type().Field(i)
+
+			if jsonTag := t.Tag.Get("json"); jsonTag != "" {
+				fieldName := ""
+				if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
+					fieldName = jsonTag[:commaIdx]
+				} else {
+					fieldName = jsonTag
+				}
+				if fieldName != "AdditionalProperties" {
+					delete(additionalProperties, fieldName)
+				}
+			}
+		}
+
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/isMap}}
+{{#isMap}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	err = json.Unmarshal(data, &var{{{classname}}})
+
+	if err != nil {
+		return err
+	}
+
+	*o = {{{classname}}}(var{{{classname}}})
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/isMap}}
+{{/parent}}
+{{^parent}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	err = json.Unmarshal(data, &var{{{classname}}})
+
+	if err != nil {
+		return err
+	}
+
+	*o = {{{classname}}}(var{{{classname}}})
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/parent}}
+{{/isAdditionalPropertiesTrue}}
+{{#isAdditionalPropertiesTrue}}
+}
+
+{{/isAdditionalPropertiesTrue}}
+{{^isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	//decoder.DisallowUnknownFields()
+	err = decoder.Decode(&var{{{classname}}})
+
+	if err != nil {
+		return err
+	}
+
+	*o = {{{classname}}}(var{{{classname}}})
+
+	return err
+}
+
+{{/hasRequired}}
+{{/isAdditionalPropertiesTrue}}
+{{#isArray}}
+func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
+	return json.Unmarshal(data, &o.Items)
+}
+
+{{/isArray}}
+{{/vendorExtensions.x-go-generate-unmarshal-json}}
+{{>nullable_model}}

--- a/pkg/cs/util.go
+++ b/pkg/cs/util.go
@@ -36,13 +36,13 @@ func GetPipelineStatus(ws int, stage string) (res []ReplicaStatus, err error) {
 
 	status, err := Get(fmt.Sprintf("workspaces/%d/pipeline/%s", ws, stage))
 	if err != nil {
-		err = fmt.Errorf("failed to get pipeline status: %e", err)
+		err = fmt.Errorf("failed to get pipeline status: %w", err)
 		return
 	}
 
 	err = json.Unmarshal(status, &res)
 	if err != nil {
-		err = fmt.Errorf("failed to unmarshal pipeline status: %e", err)
+		err = fmt.Errorf("failed to unmarshal pipeline status: %w", err)
 		return
 	}
 	return
@@ -51,18 +51,18 @@ func GetPipelineStatus(ws int, stage string) (res []ReplicaStatus, err error) {
 func Get(path string) (body []byte, err error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", GetApiUrl(), strings.TrimPrefix(path, "/")), http.NoBody)
 	if err != nil {
-		err = fmt.Errorf("failed to create request: %e", err)
+		err = fmt.Errorf("failed to create request: %w", err)
 		return
 	}
 	err = SetAuthoriziationHeader(req)
 	if err != nil {
-		err = fmt.Errorf("failed to set header: %e", err)
+		err = fmt.Errorf("failed to set header: %w", err)
 		return
 	}
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		err = fmt.Errorf("GET failed: %e", err)
+		err = fmt.Errorf("GET failed: %w", err)
 		return
 	}
 	defer func() { _ = res.Body.Close() }()
@@ -81,7 +81,7 @@ func GetApiToken() (string, error) {
 func SetAuthoriziationHeader(req *http.Request) error {
 	token, err := GetApiToken()
 	if err != nil {
-		return fmt.Errorf("failed to get API token: %e", err)
+		return fmt.Errorf("failed to get API token: %w", err)
 	}
 
 	req.Header.Set("Authorization", "Bearer "+token)


### PR DESCRIPTION
Unknown properties by default cause the generator to fail for fields that are required by the model.

We need to find a way to not break the public API by adding required fields, but to work around, allowing them will make our lives easier.

Also formats error messages as string for improved readability.