### PR TITLE
devx(gh-action): fix cp command in docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docs:
 	rm -rf docs
 	mkdir docs
 	go run -ldflags="-X 'github.com/codesphere-cloud/cs-go/pkg/out.binName=cs'" hack/gendocs/main.go 
-	cp docs/{cs,README}.md
+	cp docs/cs.md docs/README.md
 
 generate-license: generate
 	go-licenses report --template .NOTICE.template  ./... > NOTICE


### PR DESCRIPTION
```
cp docs/{cs,README}.md
```
failed in GitHub action