### PR TITLE
fead(exec,open): Add exec and open command

### DIFF
--- a/.mockery.yml
+++ b/.mockery.yml
@@ -15,9 +15,9 @@ template: testify
 template-schema: '{{.Template}}.schema.json'
 packages:
   github.com/codesphere-cloud/cs-go/cli/cmd:
+    config:
+      all: true
     interfaces:
-      Client:
-      Env:
   github.com/codesphere-cloud/cs-go/api/openapi_client:
     config:
       all: true

--- a/api/workspace.go
+++ b/api/workspace.go
@@ -17,6 +17,11 @@ func (c *Client) ListWorkspaces(teamId int) ([]Workspace, error) {
 	return workspaces, err
 }
 
+func (c *Client) GetWorkspace(workspaceId int) (Workspace, error) {
+	workspace, _, err := c.api.WorkspacesAPI.WorkspacesGetWorkspace(c.ctx, float32(workspaceId)).Execute()
+	return *workspace, err
+}
+
 func (c *Client) WorkspaceStatus(workspaceId int) (*WorkspaceStatus, error) {
 	status, _, err := c.api.WorkspacesAPI.WorkspacesGetWorkspaceStatus(c.ctx, float32(workspaceId)).Execute()
 	return status, err
@@ -39,6 +44,22 @@ func (c *Client) SetEnvVarOnWorkspace(workspaceId int, envVars map[string]string
 	req := c.api.WorkspacesAPI.WorkspacesSetEnvVar(c.ctx, float32(workspaceId)).WorkspacesListEnvVars200ResponseInner(vars)
 	_, err := c.api.WorkspacesAPI.WorkspacesSetEnvVarExecute(req)
 	return err
+}
+
+func (c *Client) ExecCommand(workspaceId int, command string, workdir string, env map[string]string) (string, string, error) {
+	cmd := openapi_client.WorkspacesExecuteCommandRequest{
+		Command:    command,
+		WorkingDir: &workdir,
+		Env:        &env,
+	}
+
+	req := c.api.WorkspacesAPI.WorkspacesExecuteCommand(c.ctx, float32(workspaceId)).WorkspacesExecuteCommandRequest(cmd)
+	res, _, err := req.Execute()
+
+	if err != nil {
+		return "", "", fmt.Errorf("failed to execute command: %w", err)
+	}
+	return res.Output, res.Error, nil
 }
 
 // Waits for a given workspace to be running.

--- a/cli/cmd/client.go
+++ b/cli/cmd/client.go
@@ -16,7 +16,9 @@ import (
 type Client interface {
 	ListTeams() ([]api.Team, error)
 	ListWorkspaces(teamId int) ([]api.Workspace, error)
+	GetWorkspace(workspaceId int) (api.Workspace, error)
 	SetEnvVarOnWorkspace(workspaceId int, vars map[string]string) error
+	ExecCommand(workspaceId int, command string, workdir string, env map[string]string) (string, string, error)
 }
 
 func NewClient(opts GlobalOptions) (Client, error) {

--- a/cli/cmd/exec.go
+++ b/cli/cmd/exec.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/codesphere-cloud/cs-go/pkg/cs"
+	"github.com/codesphere-cloud/cs-go/pkg/out"
+
+	"github.com/spf13/cobra"
+)
+
+// ExecCmd represents the exec command
+type ExecCmd struct {
+	cmd  *cobra.Command
+	Opts ExecOptions
+}
+
+type ExecOptions struct {
+	GlobalOptions
+	EnvVar  *[]string
+	WorkDir *string
+}
+
+func (c *ExecCmd) RunE(_ *cobra.Command, args []string) error {
+	command := strings.Join(args, " ")
+	fmt.Printf("running command %s\n", command)
+
+	client, err := NewClient(c.Opts.GlobalOptions)
+	if err != nil {
+		return fmt.Errorf("failed to create Codesphere client: %w", err)
+	}
+
+	return c.ExecCommand(client, command)
+}
+
+func AddExecCmd(rootCmd *cobra.Command, opts GlobalOptions) {
+	exec := ExecCmd{
+		cmd: &cobra.Command{
+			Use:   "exec",
+			Args:  cobra.MinimumNArgs(1),
+			Short: "Run a command in Codesphere workspace",
+			Long: `Run a command in a Codesphere workspace.
+  Output will be printed to STDOUT, errors to STDERR.`,
+			Example: out.FormatExampleCommands("exec", []out.Example{
+				{Cmd: "-- echo hello world", Desc: "Print `hello world`"},
+				{Cmd: "-- find .", Desc: "List all files in workspace"},
+				{Cmd: "-d user -- find .", Desc: "List all files in the user directory"},
+				{Cmd: "-e FOO=bar -- 'echo $FOO'", Desc: "Set custom environment variables for this command"},
+			}),
+		},
+		Opts: ExecOptions{GlobalOptions: opts},
+	}
+	exec.Opts.EnvVar = exec.cmd.Flags().StringArrayP("env", "e", []string{}, "Additional environment variables to pass to the command in the form key=val")
+	exec.Opts.WorkDir = exec.cmd.Flags().StringP("workdir", "d", ".", "Working directory for the command")
+	rootCmd.AddCommand(exec.cmd)
+	exec.cmd.RunE = exec.RunE
+}
+
+func (c *ExecCmd) ExecCommand(client Client, command string) error {
+	wsId, err := c.Opts.GetWorkspaceId()
+	if err != nil {
+		return fmt.Errorf("failed to get workspace ID: %w", err)
+	}
+
+	envVarMap, err := cs.ArgToEnvVarMap(*c.Opts.EnvVar)
+	if err != nil {
+		return fmt.Errorf("failed to parse environment variables: %w", err)
+	}
+
+	stdout, stderr, err := client.ExecCommand(wsId, command, *c.Opts.WorkDir, envVarMap)
+	if err != nil {
+		return fmt.Errorf("failed to exec command: %w", err)
+	}
+
+	fmt.Println("STDOUT:")
+	fmt.Println(stdout)
+	if stderr != "" {
+		fmt.Println("STDERR:")
+		fmt.Fprintln(os.Stderr, stderr)
+	}
+	return nil
+}

--- a/cli/cmd/exec_test.go
+++ b/cli/cmd/exec_test.go
@@ -1,0 +1,72 @@
+package cmd_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/codesphere-cloud/cs-go/cli/cmd"
+)
+
+var _ = Describe("Exec", func() {
+	var (
+		mockEnv    *cmd.MockEnv
+		mockClient *cmd.MockClient
+		e          *cmd.ExecCmd
+		wsId       int
+		command    string
+		workDir    string
+		envVars    []string
+	)
+
+	BeforeEach(func() {
+		envVars = []string{}
+		mockClient = cmd.NewMockClient(GinkgoT())
+		mockEnv = cmd.NewMockEnv(GinkgoT())
+		wsId = 42
+		command = "ls -al"
+	})
+
+	JustBeforeEach(func() {
+		e = &cmd.ExecCmd{
+			Opts: cmd.ExecOptions{
+				GlobalOptions: cmd.GlobalOptions{
+					Env:         mockEnv,
+					WorkspaceId: &wsId,
+				},
+				EnvVar:  &envVars,
+				WorkDir: &workDir,
+			},
+		}
+	})
+
+	Context("No workdir, no env vars set", func() {
+		It("executes the command", func() {
+			mockClient.EXPECT().ExecCommand(wsId, command, "", map[string]string{}).Return("stdout", "stderr", nil)
+			err := e.ExecCommand(mockClient, command)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("env vars set", func() {
+		BeforeEach(func() {
+			envVars = []string{"a=b", "b=c"}
+		})
+		It("executes the command with env vars", func() {
+			mockClient.EXPECT().ExecCommand(wsId, command, "", map[string]string{"a": "b", "b": "c"}).Return("stdout", "stderr", nil)
+			err := e.ExecCommand(mockClient, command)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("work dir set", func() {
+		BeforeEach(func() {
+			workDir = "user"
+		})
+		It("executes the command with workdir", func() {
+			mockClient.EXPECT().ExecCommand(wsId, command, workDir, map[string]string{}).Return("stdout", "stderr", nil)
+			err := e.ExecCommand(mockClient, command)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+})

--- a/cli/cmd/mocks.go
+++ b/cli/cmd/mocks.go
@@ -36,6 +36,123 @@ func (_m *MockClient) EXPECT() *MockClient_Expecter {
 	return &MockClient_Expecter{mock: &_m.Mock}
 }
 
+// ExecCommand provides a mock function for the type MockClient
+func (_mock *MockClient) ExecCommand(workspaceId int, command string, workdir string, env map[string]string) (string, string, error) {
+	ret := _mock.Called(workspaceId, command, workdir, env)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecCommand")
+	}
+
+	var r0 string
+	var r1 string
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(int, string, string, map[string]string) (string, string, error)); ok {
+		return returnFunc(workspaceId, command, workdir, env)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int, string, string, map[string]string) string); ok {
+		r0 = returnFunc(workspaceId, command, workdir, env)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(int, string, string, map[string]string) string); ok {
+		r1 = returnFunc(workspaceId, command, workdir, env)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+	if returnFunc, ok := ret.Get(2).(func(int, string, string, map[string]string) error); ok {
+		r2 = returnFunc(workspaceId, command, workdir, env)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockClient_ExecCommand_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecCommand'
+type MockClient_ExecCommand_Call struct {
+	*mock.Call
+}
+
+// ExecCommand is a helper method to define mock.On call
+//   - workspaceId
+//   - command
+//   - workdir
+//   - env
+func (_e *MockClient_Expecter) ExecCommand(workspaceId interface{}, command interface{}, workdir interface{}, env interface{}) *MockClient_ExecCommand_Call {
+	return &MockClient_ExecCommand_Call{Call: _e.mock.On("ExecCommand", workspaceId, command, workdir, env)}
+}
+
+func (_c *MockClient_ExecCommand_Call) Run(run func(workspaceId int, command string, workdir string, env map[string]string)) *MockClient_ExecCommand_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int), args[1].(string), args[2].(string), args[3].(map[string]string))
+	})
+	return _c
+}
+
+func (_c *MockClient_ExecCommand_Call) Return(s string, s1 string, err error) *MockClient_ExecCommand_Call {
+	_c.Call.Return(s, s1, err)
+	return _c
+}
+
+func (_c *MockClient_ExecCommand_Call) RunAndReturn(run func(workspaceId int, command string, workdir string, env map[string]string) (string, string, error)) *MockClient_ExecCommand_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetWorkspace provides a mock function for the type MockClient
+func (_mock *MockClient) GetWorkspace(workspaceId int) (api.Workspace, error) {
+	ret := _mock.Called(workspaceId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWorkspace")
+	}
+
+	var r0 api.Workspace
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int) (api.Workspace, error)); ok {
+		return returnFunc(workspaceId)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int) api.Workspace); ok {
+		r0 = returnFunc(workspaceId)
+	} else {
+		r0 = ret.Get(0).(api.Workspace)
+	}
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(workspaceId)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_GetWorkspace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetWorkspace'
+type MockClient_GetWorkspace_Call struct {
+	*mock.Call
+}
+
+// GetWorkspace is a helper method to define mock.On call
+//   - workspaceId
+func (_e *MockClient_Expecter) GetWorkspace(workspaceId interface{}) *MockClient_GetWorkspace_Call {
+	return &MockClient_GetWorkspace_Call{Call: _e.mock.On("GetWorkspace", workspaceId)}
+}
+
+func (_c *MockClient_GetWorkspace_Call) Run(run func(workspaceId int)) *MockClient_GetWorkspace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int))
+	})
+	return _c
+}
+
+func (_c *MockClient_GetWorkspace_Call) Return(v api.Workspace, err error) *MockClient_GetWorkspace_Call {
+	_c.Call.Return(v, err)
+	return _c
+}
+
+func (_c *MockClient_GetWorkspace_Call) RunAndReturn(run func(workspaceId int) (api.Workspace, error)) *MockClient_GetWorkspace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListTeams provides a mock function for the type MockClient
 func (_mock *MockClient) ListTeams() ([]api.Team, error) {
 	ret := _mock.Called()
@@ -189,6 +306,78 @@ func (_c *MockClient_SetEnvVarOnWorkspace_Call) Return(err error) *MockClient_Se
 }
 
 func (_c *MockClient_SetEnvVarOnWorkspace_Call) RunAndReturn(run func(workspaceId int, vars map[string]string) error) *MockClient_SetEnvVarOnWorkspace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// NewMockBrowser creates a new instance of MockBrowser. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewMockBrowser(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *MockBrowser {
+	mock := &MockBrowser{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}
+
+// MockBrowser is an autogenerated mock type for the Browser type
+type MockBrowser struct {
+	mock.Mock
+}
+
+type MockBrowser_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *MockBrowser) EXPECT() *MockBrowser_Expecter {
+	return &MockBrowser_Expecter{mock: &_m.Mock}
+}
+
+// OpenIde provides a mock function for the type MockBrowser
+func (_mock *MockBrowser) OpenIde(path string) error {
+	ret := _mock.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OpenIde")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(path)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBrowser_OpenIde_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OpenIde'
+type MockBrowser_OpenIde_Call struct {
+	*mock.Call
+}
+
+// OpenIde is a helper method to define mock.On call
+//   - path
+func (_e *MockBrowser_Expecter) OpenIde(path interface{}) *MockBrowser_OpenIde_Call {
+	return &MockBrowser_OpenIde_Call{Call: _e.mock.On("OpenIde", path)}
+}
+
+func (_c *MockBrowser_OpenIde_Call) Run(run func(path string)) *MockBrowser_OpenIde_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockBrowser_OpenIde_Call) Return(err error) *MockBrowser_OpenIde_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBrowser_OpenIde_Call) RunAndReturn(run func(path string) error) *MockBrowser_OpenIde_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/cli/cmd/open-workspace.go
+++ b/cli/cmd/open-workspace.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/codesphere-cloud/cs-go/pkg/cs"
+	"github.com/codesphere-cloud/cs-go/pkg/out"
+	"github.com/spf13/cobra"
+)
+
+// OpenWorkspaceCmd represents the workspace command
+type OpenWorkspaceCmd struct {
+	cmd  *cobra.Command
+	Opts GlobalOptions
+}
+
+type Browser interface {
+	OpenIde(path string) error
+}
+
+func (c *OpenWorkspaceCmd) RunE(_ *cobra.Command, args []string) error {
+	client, err := NewClient(c.Opts)
+	if err != nil {
+		return fmt.Errorf("failed to create Codesphere client: %w", err)
+	}
+
+	wsId, err := c.Opts.GetWorkspaceId()
+	if err != nil {
+		return fmt.Errorf("failed to get workspace ID: %w", err)
+	}
+
+	return c.OpenWorkspace(cs.NewBrowser(), client, wsId)
+}
+
+func AddOpenWorkspaceCmd(open *cobra.Command, opts GlobalOptions) {
+	workspace := OpenWorkspaceCmd{
+		cmd: &cobra.Command{
+			Use:   "workspace",
+			Short: "Open workspace in web browser",
+			Long:  `Open workspace in the Codesphere IDE.`,
+			Example: out.FormatExampleCommands("open workspace", []out.Example{
+				{Cmd: "-w 42", Desc: "open workspace 42 in web browser"},
+				{Cmd: "", Desc: "open workspace set by environment variable CS_WORKSPACE_ID"},
+			}),
+		},
+		Opts: opts,
+	}
+	open.AddCommand(workspace.cmd)
+	workspace.cmd.RunE = workspace.RunE
+}
+
+func (cmd *OpenWorkspaceCmd) OpenWorkspace(browser Browser, client Client, wsId int) error {
+	workspace, err := client.GetWorkspace(wsId)
+	if err != nil {
+		return fmt.Errorf("failed to get workspace: %w", err)
+	}
+
+	fmt.Printf("Opening workspace %d in Codesphere IDE\n", wsId)
+
+	err = browser.OpenIde(fmt.Sprintf("teams/%d/workspaces/%d", workspace.TeamId, wsId))
+	if err != nil {
+		return fmt.Errorf("failed to open web browser: %w", err)
+	}
+
+	return nil
+}

--- a/cli/cmd/open.go
+++ b/cli/cmd/open.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/codesphere-cloud/cs-go/pkg/cs"
+)
+
+// OpenCmd represents the open command
+type OpenCmd struct {
+	cmd *cobra.Command
+}
+
+func (c *OpenCmd) RunE(_ *cobra.Command, args []string) error {
+	//Command execution goes here
+
+	fmt.Println("Opening Codesphere IDE")
+	return cs.NewBrowser().OpenIde("")
+}
+
+func AddOpenCmd(rootCmd *cobra.Command, opts GlobalOptions) {
+	open := OpenCmd{
+		cmd: &cobra.Command{
+			Use:   "open",
+			Short: "Open the codesphere IDE",
+			Long:  `Open the codesphere IDE.`,
+		},
+	}
+	rootCmd.AddCommand(open.cmd)
+	open.cmd.RunE = open.RunE
+	AddOpenWorkspaceCmd(open.cmd, opts)
+}

--- a/cli/cmd/open_workspace_test.go
+++ b/cli/cmd/open_workspace_test.go
@@ -1,0 +1,47 @@
+package cmd_test
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/codesphere-cloud/cs-go/api"
+	"github.com/codesphere-cloud/cs-go/cli/cmd"
+)
+
+var _ = Describe("GenerateWorkspacePath", func() {
+	var (
+		mockEnv     *cmd.MockEnv
+		mockClient  *cmd.MockClient
+		mockBrowser *cmd.MockBrowser
+		o           *cmd.OpenWorkspaceCmd
+		wsId        int
+		teamId      int
+	)
+
+	JustBeforeEach(func() {
+		mockClient = cmd.NewMockClient(GinkgoT())
+		mockBrowser = cmd.NewMockBrowser(GinkgoT())
+		mockEnv = cmd.NewMockEnv(GinkgoT())
+		wsId = 42
+		teamId = 21
+		o = &cmd.OpenWorkspaceCmd{
+			Opts: cmd.GlobalOptions{
+				Env:         mockEnv,
+				WorkspaceId: &wsId,
+			},
+		}
+	})
+
+	It("queries the workspace and opens the IDE path", func() {
+		mockClient.EXPECT().GetWorkspace(wsId).Return(api.Workspace{
+			Id:     wsId,
+			TeamId: teamId,
+		}, nil)
+		mockBrowser.EXPECT().OpenIde(fmt.Sprintf("teams/%d/workspaces/%d", teamId, wsId)).Return(nil)
+		err := o.OpenWorkspace(mockBrowser, mockClient, wsId)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+})

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -26,14 +26,14 @@ type Env interface {
 }
 
 func (o GlobalOptions) GetApiUrl() string {
-	if o.ApiUrl != nil {
+	if o.ApiUrl != nil && *o.ApiUrl != "" {
 		return *o.ApiUrl
 	}
 	return o.Env.GetApiUrl()
 }
 
 func (o GlobalOptions) GetTeamId() (int, error) {
-	if o.TeamId != nil {
+	if o.TeamId != nil && *o.TeamId != -1 {
 		return *o.TeamId, nil
 	}
 	wsId, err := o.Env.GetTeamId()
@@ -47,7 +47,7 @@ func (o GlobalOptions) GetTeamId() (int, error) {
 }
 
 func (o GlobalOptions) GetWorkspaceId() (int, error) {
-	if o.WorkspaceId != nil {
+	if o.WorkspaceId != nil && *o.WorkspaceId != -1 {
 		return *o.WorkspaceId, nil
 	}
 	wsId, err := o.Env.GetWorkspaceId()
@@ -68,15 +68,19 @@ func GetRootCmd() *cobra.Command {
 	}
 
 	opts := GlobalOptions{Env: cs.NewEnv()}
+
+	opts.ApiUrl = rootCmd.PersistentFlags().StringP("api", "a", "", "URL of Codesphere API (can also be CS_API)")
+	opts.TeamId = rootCmd.PersistentFlags().IntP("team", "t", -1, "Team ID (relevant for some commands, can also be CS_TEAM_ID)")
+	opts.WorkspaceId = rootCmd.PersistentFlags().IntP("workspace", "w", -1, "Workspace ID (relevant for some commands, can also be CS_WORKSPACE_ID)")
+
+	AddExecCmd(rootCmd, opts)
 	AddLogCmd(rootCmd, opts)
 	AddListCmd(rootCmd, opts)
 	AddSetEnvVarCmd(rootCmd, opts)
 	AddVersionCmd(rootCmd)
 	AddLicensesCmd(rootCmd)
+	AddOpenCmd(rootCmd, opts)
 
-	opts.ApiUrl = rootCmd.PersistentFlags().StringP("api", "a", "https://codesphere.com/api", "URL of Codesphere API (can also be CS_API)")
-	opts.TeamId = rootCmd.PersistentFlags().IntP("team", "t", -1, "Team ID (relevant for some commands, can also be CS_TEAM_ID)")
-	opts.WorkspaceId = rootCmd.PersistentFlags().IntP("workspace", "w", -1, "Workspace ID (relevant for some commands, can also be CS_WORKSPACE_ID)")
 	return rootCmd
 }
 

--- a/cli/cmd/set-env-vars.go
+++ b/cli/cmd/set-env-vars.go
@@ -5,8 +5,8 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/codesphere-cloud/cs-go/pkg/cs"
 	"github.com/codesphere-cloud/cs-go/pkg/out"
 	"github.com/spf13/cobra"
 )
@@ -53,14 +53,9 @@ func (l *SetEnvVarCmd) RunE(_ *cobra.Command, args []string) (err error) {
 }
 
 func (l *SetEnvVarCmd) SetEnvironmentVariables(client Client) (err error) {
-	envVarMap := map[string]string{}
-	for _, v := range *l.Opts.EnvVar {
-		split := strings.Split(v, "=")
-		if len(split) != 2 {
-			return fmt.Errorf("invalid environment variable argument: %s", v)
-
-		}
-		envVarMap[split[0]] = split[1]
+	envVarMap, err := cs.ArgToEnvVarMap(*l.Opts.EnvVar)
+	if err != nil {
+		return fmt.Errorf("failed to parse environment variables: %w", err)
 	}
 	wsId, err := l.Opts.GetWorkspaceId()
 	if err != nil {

--- a/cli/cmd/set_env_vars_test.go
+++ b/cli/cmd/set_env_vars_test.go
@@ -68,7 +68,7 @@ var _ = Describe("SetEnvVars", func() {
 		})
 		It("doesn't set environment variables", func() {
 			err := e.SetEnvironmentVariables(mockClient)
-			Expect(err).To(MatchError("invalid environment variable argument: helloworld"))
+			Expect(err).To(MatchError("failed to parse environment variables: invalid environment variable argument: helloworld"))
 		})
 
 	})

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -28,7 +28,7 @@ func AddVersionCmd(rootCmd *cobra.Command) {
 		cmd: &cobra.Command{
 			Use:   "version",
 			Short: "Print version",
-			Long:  `Prints current version of Codesphere CLI.`,
+			Long:  `Print current version of Codesphere CLI.`,
 		},
 	}
 	rootCmd.AddCommand(version.cmd)

--- a/pkg/cs/browser.go
+++ b/pkg/cs/browser.go
@@ -1,0 +1,42 @@
+package cs
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+type Browser struct{}
+
+func NewBrowser() *Browser {
+	return &Browser{}
+}
+
+func (b *Browser) OpenIde(path string) error {
+	re := regexp.MustCompile(`/api`)
+	ideUrl := re.ReplaceAllString(NewEnv().GetApiUrl(), "/ide")
+	if !strings.HasPrefix(path, "/") {
+		ideUrl += "/"
+	}
+	url := ideUrl + path
+
+	fmt.Printf("Opening %s in web browser...\n", url)
+
+	var err error
+	switch runtime.GOOS {
+	case "darwin":
+		err = exec.Command("open", url).Run()
+	case "linux":
+		err = exec.Command("xdg-open", url).Run()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Run()
+	default:
+		return fmt.Errorf("platform not supported: %s", runtime.GOOS)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to open web browser: %w", err)
+	}
+	return nil
+}

--- a/pkg/cs/util.go
+++ b/pkg/cs/util.go
@@ -76,3 +76,16 @@ func GetRoleName(role int) string {
 	}
 	return "Admin"
 }
+
+func ArgToEnvVarMap(input []string) (map[string]string, error) {
+	res := map[string]string{}
+	for _, v := range input {
+		split := strings.Split(v, "=")
+		if len(split) != 2 {
+			return res, fmt.Errorf("invalid environment variable argument: %s", v)
+
+		}
+		res[split[0]] = split[1]
+	}
+	return res, nil
+}


### PR DESCRIPTION
* exec can be used to run commands in a workspace
* open can be used to open the Codesphere IDE, e.g. to open a workspace in the browser