### PR TITLE
feat(cli): Add ListOrganizations Feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,13 @@ test:
 	# -count=1 to disable caching test results
 	go test ./api/... ./cli/... ./pkg/... -count=1
 
+coverage:
+	go test ./api/... ./cli/... ./pkg/... -count=1 -coverprofile=coverage.out
+	go tool cover -func=coverage.out
+
+coverage-html: coverage
+	go tool cover -html=coverage.out
+
 test-int: build
 	go test ./int/... -count=1 -v
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ The `cs` CLI supports several global options that you can set via command-line f
 |               | `--api`<br/>`-a`       | `CS_API`             | URL of the Codesphere API. Default: `https://cloud.codesphere.com/api` |
 | Some commands | `--team`<br/>`-t`      | `CS_TEAM_ID`         | Your Codesphere Team ID. This is relevant for commands operating on a specific team. |
 | Some commands | `--workspace`<br/>`-w` | `CS_WORKSPACE_ID`    | Your Codesphere Workspace ID. Relevant for commands targeting a specific workspace. |
+| Some commands | `--org`<br/>`-o`       | `CS_ORG_ID`          | Your Codesphere Organization ID. Relevant for commands operating on a specific organization. |
 
-**Note on Team ID and Workspace ID:** If you don't provide these via a flag, the CLI will try to get them from the corresponding environment variables (`CS_TEAM_ID`, `CS_WORKSPACE_ID`). If they're still not found and a command requires them, the CLI will return an error.
+
+**Note on Team ID, Workspace ID and Organization ID:** If you don't provide these via a flag, the CLI will try to get them from the corresponding environment variables (`CS_TEAM_ID`, `CS_WORKSPACE_ID`, `CS_ORG_ID`). If they're still not found and a command requires them, the CLI will return an error.
 
 #### Available Commands
 
@@ -121,6 +123,7 @@ Integration tests verify the CLI works correctly against live Codesphere environ
 **Prerequisites:**
 - `CS_TOKEN` - Your Codesphere API token
 - `CS_TEAM_ID` - Your team ID
+- `CS_ORG_ID` - Your Organization ID
 
 Run integration tests:
 

--- a/api/client.go
+++ b/api/client.go
@@ -145,3 +145,8 @@ func (c *Client) ListBaseimages() ([]Baseimage, error) {
 	baseimages, r, err := c.api.MetadataAPI.MetadataGetWorkspaceBaseImages(c.ctx).Execute()
 	return baseimages, errors.FormatAPIError(r, err)
 }
+
+func (c *Client) ListOrganizations() ([]Organization, error) {
+	organizations, r, err := c.api.OrganizationsAPI.OrganizationsListOrganizations(c.ctx).Execute()
+	return organizations, errors.FormatAPIError(r, err)
+}

--- a/api/types.go
+++ b/api/types.go
@@ -15,7 +15,7 @@ type Domain = openapi.DomainsGetDomain200Response
 type DomainVerificationStatus = openapi.DomainsGetDomain200ResponseDomainVerificationStatus
 type UpdateDomainArgs = openapi.DomainsUpdateDomainRequest
 type PathToWorkspaces = map[string][]*Workspace
-
+type Organization = openapi.OrganizationsListOrganizations200ResponseInner
 type Workspace = openapi.WorkspacesGetWorkspace200Response
 type Baseimage = openapi.MetadataGetWorkspaceBaseImages200ResponseInner
 type WorkspaceStatus = openapi.WorkspacesGetWorkspaceStatus200Response

--- a/cli/cmd/client.go
+++ b/cli/cmd/client.go
@@ -19,6 +19,7 @@ type Client interface {
 	ListTeams() ([]api.Team, error)
 	ListWorkspaces(teamId int) ([]api.Workspace, error)
 	ListBaseimages() ([]api.Baseimage, error)
+	ListOrganizations() ([]api.Organization, error)
 	GetWorkspace(workspaceId int) (api.Workspace, error)
 	WorkspaceStatus(workspaceId int) (*api.WorkspaceStatus, error)
 	WaitForWorkspaceRunning(workspace *api.Workspace, timeout time.Duration) error

--- a/cli/cmd/list.go
+++ b/cli/cmd/list.go
@@ -52,5 +52,6 @@ func AddListCmd(rootCmd *cobra.Command, opts *GlobalOptions) {
 	addListWorkspacesCmd(l.cmd, listOpts)
 	AddListBaseimagesCmd(l.cmd, listOpts)
 	addListTeamsCmd(l.cmd, listOpts)
+	AddListOrgCmd(l.cmd, listOpts)
 	AddListPlansCmd(l.cmd, listOpts)
 }

--- a/cli/cmd/list_organizations.go
+++ b/cli/cmd/list_organizations.go
@@ -1,0 +1,74 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/codesphere-cloud/cs-go/api"
+	"github.com/codesphere-cloud/cs-go/pkg/io"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+type ListOrgCmd struct {
+	cmd           *cobra.Command
+	Opts          *ListOptions
+	ClientFactory func(GlobalOptions) (Client, error)
+}
+
+func AddListOrgCmd(p *cobra.Command, opts *ListOptions,
+) {
+	l := ListOrgCmd{
+		cmd: &cobra.Command{
+			Use:   "org",
+			Short: "List organizations",
+			Long:  `List organizations available in Codesphere`,
+			Example: io.FormatExampleCommands("list org", []io.Example{
+				{Desc: "List all organizations"},
+			}),
+		},
+		Opts:          opts,
+		ClientFactory: NewClient, // Default to the real client in production
+	}
+	l.cmd.RunE = l.RunE
+	AddCmd(p, l.cmd)
+}
+
+func (l *ListOrgCmd) RunE(_ *cobra.Command, args []string) (err error) {
+	client, err := l.ClientFactory(*l.Opts.GlobalOptions) // Use the injected factory
+	if err != nil {
+		return fmt.Errorf("failed to create Codesphere client: %w", err)
+	}
+
+	_, err = l.ListOrganizations(client)
+	if err != nil {
+		return fmt.Errorf("failed to list organizations: %w", err)
+	}
+
+	return nil
+}
+
+func (l *ListOrgCmd) ListOrganizations(client Client) ([]api.Organization, error) {
+	orgs, err := client.ListOrganizations()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list organizations: %w", err)
+	}
+
+	switch l.Opts.OutputFormat {
+	case OutputFormatJSON:
+		return orgs, io.PrintJSON(orgs)
+	case OutputFormatYAML:
+		return orgs, io.PrintYAML(orgs)
+	}
+
+	t := io.GetTableWriter()
+	t.AppendHeader(table.Row{"ID", "Name"})
+	for _, org := range orgs {
+		t.AppendRow(table.Row{org.Id, org.Name})
+	}
+	t.Render()
+
+	return orgs, nil
+}

--- a/cli/cmd/list_organizations_test.go
+++ b/cli/cmd/list_organizations_test.go
@@ -16,7 +16,6 @@ import (
 	"go.yaml.in/yaml/v2"
 
 	"github.com/codesphere-cloud/cs-go/api"
-	//"github.com/codesphere-cloud/cs-go/api/openapi_client"
 	"github.com/codesphere-cloud/cs-go/cli/cmd"
 )
 
@@ -25,7 +24,6 @@ var _ = Describe("Organization", func() {
 		mockEnv    *cmd.MockEnv
 		mockClient *cmd.MockClient
 		l          cmd.ListOrgCmd
-		//organizationApiMock *openapi_client.MockOrganizationsAPI
 	)
 
 	BeforeEach(func() {
@@ -40,8 +38,6 @@ var _ = Describe("Organization", func() {
 			},
 			ClientFactory: cmd.NewClient, // Default to real client, will be overridden in specific tests
 		}
-		//organizationApiMock = openapi_client.NewMockOrganizationsAPI(GinkgoT())
-
 	})
 
 	AfterEach(func() {

--- a/cli/cmd/list_organizations_test.go
+++ b/cli/cmd/list_organizations_test.go
@@ -128,8 +128,11 @@ var _ = Describe("Organization", func() {
 
 			orgs, err := l.ListOrganizations(mockClient)
 
+			Expect(err).NotTo(HaveOccurred())
+			Expect(orgs).To(Equal(expectedOrgs))
+
 			// Restore Stdout
-			w.Close()
+			err = w.Close()
 			var buf bytes.Buffer
 			_, _ = io.Copy(&buf, r)
 			os.Stdout = oldStdout
@@ -158,9 +161,13 @@ var _ = Describe("Organization", func() {
 			os.Stdout = w
 
 			orgs, err := l.ListOrganizations(mockClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(orgs).To(Equal(expectedOrgs))
+
+
 
 			// Restore Stdout
-			w.Close()
+			err = w.Close()
 			var buf bytes.Buffer
 			_, _ = io.Copy(&buf, r)
 			os.Stdout = oldStdout

--- a/cli/cmd/list_organizations_test.go
+++ b/cli/cmd/list_organizations_test.go
@@ -1,0 +1,214 @@
+// Copyright (c) Codesphere Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v2"
+
+	"github.com/codesphere-cloud/cs-go/api"
+	//"github.com/codesphere-cloud/cs-go/api/openapi_client"
+	"github.com/codesphere-cloud/cs-go/cli/cmd"
+)
+
+var _ = Describe("Organization", func() {
+	var (
+		mockEnv    *cmd.MockEnv
+		mockClient *cmd.MockClient
+		l          cmd.ListOrgCmd
+		//organizationApiMock *openapi_client.MockOrganizationsAPI
+	)
+
+	BeforeEach(func() {
+		mockEnv = cmd.NewMockEnv(GinkgoT())
+		mockClient = cmd.NewMockClient(GinkgoT())
+		l = cmd.ListOrgCmd{
+			Opts: &cmd.ListOptions{
+				GlobalOptions: &cmd.GlobalOptions{
+					Env:   mockEnv,
+					OrgId: -1, // force using the env mock to get a org ID
+				},
+			},
+			ClientFactory: cmd.NewClient, // Default to real client, will be overridden in specific tests
+		}
+		//organizationApiMock = openapi_client.NewMockOrganizationsAPI(GinkgoT())
+
+	})
+
+	AfterEach(func() {
+		mockEnv.AssertExpectations(GinkgoT())
+		mockClient.AssertExpectations(GinkgoT())
+	})
+
+	Context("RunE Method", func() {
+		It("successful execution", func() {
+			mockEnv.EXPECT().GetApiToken().Return("test-token", nil).Maybe()
+			mockEnv.EXPECT().GetApiUrl().Return("https://cloud.codesphere.com/api").Maybe()
+
+			// Override the ClientFactory to return our mockClient
+			l.ClientFactory = func(opts cmd.GlobalOptions) (cmd.Client, error) {
+				return mockClient, nil
+			}
+
+			mockClient.EXPECT().ListOrganizations().Return([]api.Organization{}, nil).Once()
+			err := l.RunE(nil, []string{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("fails when client creation fails due to missing API token", func() {
+			// Mock failure to get API token
+			mockEnv.EXPECT().GetApiToken().Return("", errors.New("CS_TOKEN env var required, but not set"))
+
+			err := l.RunE(nil, []string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create Codesphere client"))
+		})
+		It("fails when client creation fails due to invalid API URL", func() {
+			// Mock successful token
+			mockEnv.EXPECT().GetApiToken().Return("test-token", nil)
+			mockEnv.EXPECT().GetApiUrl().Return("ht tp://invalid url with spaces")
+
+			err := l.RunE(nil, []string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create Codesphere client"))
+		})
+
+		It("successfully creates client but fails when the API call fails", func() {
+			// Mock successful token and URL to allow NewClient to succeed
+			mockEnv.EXPECT().GetApiToken().Return("test-token", nil).Maybe()
+			mockEnv.EXPECT().GetApiUrl().Return("https://cloud.codesphere.com/api").Maybe()
+
+			// We should also use the mock factory here to simulate an API failure deterministically
+			l.ClientFactory = func(opts cmd.GlobalOptions) (cmd.Client, error) {
+				return mockClient, nil
+			}
+			mockClient.EXPECT().ListOrganizations().Return(nil, errors.New("API error")).Once()
+
+			err := l.RunE(nil, []string{})
+			Expect(err).To(MatchError(ContainSubstring("failed to list organizations: API error")))
+		})
+	})
+
+	Context("ListOrg Method", func() {
+		It("successfully lists organizations", func() {
+			expectedOrgs := []api.Organization{
+				{Id: "d90e5f82-445e-4397-a90e-74d55cd4be3c", Name: "fakeForTeam0"},
+				{Id: "d90e5f82-445e-4397-a90e-74d55cd4be4c", Name: "fakeForTeam1"},
+			}
+			mockClient.EXPECT().ListOrganizations().Return(expectedOrgs, nil).Once()
+
+			orgs, err := l.ListOrganizations(mockClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(orgs).To(Equal(expectedOrgs))
+		})
+
+		It("returns an empty list without error when no organizations exist", func() {
+			mockClient.EXPECT().ListOrganizations().Return([]api.Organization{}, nil).Once()
+			orgs, err := l.ListOrganizations(mockClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(orgs).To(BeEmpty())
+		})
+
+		It("successfully lists organizations in JSON format", func() {
+			l.Opts.OutputFormat = cmd.OutputFormatJSON
+			expectedOrgs := []api.Organization{
+				{Id: "d90e5f82-445e-4397-a90e-74d55cd4be3c", Name: "fakeForTeam0"},
+				{Id: "d90e5f82-445e-4397-a90e-74d55cd4be4c", Name: "fakeForTeam1"},
+			}
+			mockClient.EXPECT().ListOrganizations().Return(expectedOrgs, nil).Once()
+
+			// Capture Stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			orgs, err := l.ListOrganizations(mockClient)
+
+			// Restore Stdout
+			w.Close()
+			var buf bytes.Buffer
+			_, _ = io.Copy(&buf, r)
+			os.Stdout = oldStdout
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(orgs).To(Equal(expectedOrgs))
+
+			// Verify actual JSON output
+			var actualOrgs []api.Organization
+			err = json.Unmarshal(buf.Bytes(), &actualOrgs)
+			Expect(err).NotTo(HaveOccurred(), "The output printed to console was not valid JSON")
+			Expect(actualOrgs).To(Equal(expectedOrgs))
+		})
+
+		It("successfully lists organizations in YAML format", func() {
+			l.Opts.OutputFormat = cmd.OutputFormatYAML
+			expectedOrgs := []api.Organization{
+				{Id: "d90e5f82-445e-4397-a90e-74d55cd4be3c", Name: "fakeForTeam0"},
+				{Id: "d90e5f82-445e-4397-a90e-74d55cd4be4c", Name: "fakeForTeam1"},
+			}
+			mockClient.EXPECT().ListOrganizations().Return(expectedOrgs, nil).Once()
+
+			// Capture Stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			orgs, err := l.ListOrganizations(mockClient)
+
+			// Restore Stdout
+			w.Close()
+			var buf bytes.Buffer
+			_, _ = io.Copy(&buf, r)
+			os.Stdout = oldStdout
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(orgs).To(Equal(expectedOrgs))
+
+			// Verify actual YAML output
+			var actualOrgs []api.Organization
+
+			err = yaml.Unmarshal(buf.Bytes(), &actualOrgs)
+			Expect(err).NotTo(HaveOccurred(), "The output printed to console was not valid YAML")
+			Expect(actualOrgs).To(Equal(expectedOrgs))
+		})
+	})
+})
+
+var _ = Describe("AddListOrgCmd", func() {
+	var (
+		parentCmd *cobra.Command
+		listOpts  *cmd.ListOptions
+	)
+
+	BeforeEach(func() {
+		parentCmd = &cobra.Command{Use: "list"}
+		listOpts = &cmd.ListOptions{
+			GlobalOptions: &cmd.GlobalOptions{},
+		}
+	})
+
+	It("adds the org command with correct properties", func() {
+		cmd.AddListOrgCmd(parentCmd, listOpts)
+
+		var orgCmd *cobra.Command
+		for _, c := range parentCmd.Commands() {
+			if c.Use == "org" {
+				orgCmd = c
+				break
+			}
+		}
+
+		Expect(orgCmd).NotTo(BeNil())
+		Expect(orgCmd.Use).To(Equal("org"))
+		Expect(orgCmd.Short).To(Equal("List organizations"))
+		Expect(orgCmd.RunE).NotTo(BeNil())
+	})
+})

--- a/cli/cmd/mocks.go
+++ b/cli/cmd/mocks.go
@@ -539,6 +539,61 @@ func (_c *MockClient_ListBaseimages_Call) RunAndReturn(run func() ([]api.Baseima
 	return _c
 }
 
+// ListOrganizations provides a mock function for the type MockClient
+func (_mock *MockClient) ListOrganizations() ([]api.Organization, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListOrganizations")
+	}
+
+	var r0 []api.Organization
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() ([]api.Organization, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() []api.Organization); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]api.Organization)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_ListOrganizations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListOrganizations'
+type MockClient_ListOrganizations_Call struct {
+	*mock.Call
+}
+
+// ListOrganizations is a helper method to define mock.On call
+func (_e *MockClient_Expecter) ListOrganizations() *MockClient_ListOrganizations_Call {
+	return &MockClient_ListOrganizations_Call{Call: _e.mock.On("ListOrganizations")}
+}
+
+func (_c *MockClient_ListOrganizations_Call) Run(run func()) *MockClient_ListOrganizations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockClient_ListOrganizations_Call) Return(vs []api.Organization, err error) *MockClient_ListOrganizations_Call {
+	_c.Call.Return(vs, err)
+	return _c
+}
+
+func (_c *MockClient_ListOrganizations_Call) RunAndReturn(run func() ([]api.Organization, error)) *MockClient_ListOrganizations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListTeams provides a mock function for the type MockClient
 func (_mock *MockClient) ListTeams() ([]api.Team, error) {
 	ret := _mock.Called()
@@ -1442,6 +1497,59 @@ func (_c *MockEnv_GetApiUrl_Call) Return(s string) *MockEnv_GetApiUrl_Call {
 }
 
 func (_c *MockEnv_GetApiUrl_Call) RunAndReturn(run func() string) *MockEnv_GetApiUrl_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetOrgId provides a mock function for the type MockEnv
+func (_mock *MockEnv) GetOrgId() (int, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrgId")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() int); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockEnv_GetOrgId_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrgId'
+type MockEnv_GetOrgId_Call struct {
+	*mock.Call
+}
+
+// GetOrgId is a helper method to define mock.On call
+func (_e *MockEnv_Expecter) GetOrgId() *MockEnv_GetOrgId_Call {
+	return &MockEnv_GetOrgId_Call{Call: _e.mock.On("GetOrgId")}
+}
+
+func (_c *MockEnv_GetOrgId_Call) Run(run func()) *MockEnv_GetOrgId_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockEnv_GetOrgId_Call) Return(n int, err error) *MockEnv_GetOrgId_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockEnv_GetOrgId_Call) RunAndReturn(run func() (int, error)) *MockEnv_GetOrgId_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -15,6 +15,7 @@ type GlobalOptions struct {
 	ApiUrl      string
 	TeamId      int
 	WorkspaceId int
+	OrgId       int
 	Env         Env
 	Verbose     bool
 }
@@ -23,6 +24,7 @@ type Env interface {
 	GetApiToken() (string, error)
 	GetTeamId() (int, error)
 	GetWorkspaceId() (int, error)
+	GetOrgId() (int, error)
 	GetApiUrl() string
 }
 
@@ -59,6 +61,21 @@ func (o GlobalOptions) GetWorkspaceId() (int, error) {
 		return -1, errors.New("workspace ID not set, use -w or CS_WORKSPACE_ID to set it")
 	}
 	return wsId, nil
+}
+
+func (o GlobalOptions) GetOrgId() (int, error) {
+	if o.OrgId != -1 {
+		return o.OrgId, nil
+	}
+	orgId, err := o.Env.GetOrgId()
+	if err != nil {
+		return -1, err
+	}
+	if orgId < 0 {
+		// Note: No global flag for org-id currently exists in GetRootCmd
+		return -1, errors.New("organization ID not set, use CS_ORG_ID to set it")
+	}
+	return orgId, nil
 }
 
 // AddCmd adds a command, inheriting the parent's Args validator if not explicitly set.

--- a/docs/cs_list.md
+++ b/docs/cs_list.md
@@ -33,6 +33,7 @@ $ cs list workspaces
 
 * [cs](cs.md)	 - The Codesphere CLI
 * [cs list baseimages](cs_list_baseimages.md)	 - List baseimages
+* [cs list org](cs_list_org.md)	 - List organizations
 * [cs list plans](cs_list_plans.md)	 - List available plans
 * [cs list teams](cs_list_teams.md)	 - List teams
 * [cs list workspaces](cs_list_workspaces.md)	 - List workspaces

--- a/docs/cs_list_org.md
+++ b/docs/cs_list_org.md
@@ -1,0 +1,39 @@
+## cs list org
+
+List organizations
+
+### Synopsis
+
+List organizations available in Codesphere
+
+```
+cs list org [flags]
+```
+
+### Examples
+
+```
+# List all organizations
+$ cs list org 
+```
+
+### Options
+
+```
+  -h, --help   help for org
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --api string      URL of Codesphere API (can also be CS_API)
+  -o, --output string   Output format (table, json, yaml) (default "table")
+  -t, --team int        Team ID (relevant for some commands, can also be CS_TEAM_ID) (default -1)
+  -v, --verbose         Verbose output
+  -w, --workspace int   Workspace ID (relevant for some commands, can also be CS_WORKSPACE_ID) (default -1)
+```
+
+### SEE ALSO
+
+* [cs list](cs_list.md)	 - List resources
+

--- a/pkg/cs/env.go
+++ b/pkg/cs/env.go
@@ -38,6 +38,10 @@ func (e *Environment) GetTeamId() (int, error) {
 	return e.ReadNumericEnv("CS_TEAM_ID")
 }
 
+func (e *Environment) GetOrgId() (int, error) {
+	return e.ReadNumericEnv("CS_ORG_ID")
+}
+
 func (e *Environment) ReadNumericEnv(env string) (int, error) {
 	envValue := os.Getenv(env)
 	if envValue == "" {


### PR DESCRIPTION
This commit introduces several improvements to the CLI command testing infrastructure:


- **ListOrganizations:** Implemented the first part of the Organizations API. The CLI is no able to list Organizations the User Token belongs too.
- **ClientFactory Pattern:** Implemented the `ClientFactory` pattern for `ListOrgCmd` and  to allow for dependency injection of the `Client` improving test isolation and enabling more robust unit testing.
- **Command Registration Tests:** Added a unit test for `AddListOrgCmd` to verify that the command is correctly registered with its parent and has the expected properties (`Use`, `Short`, `RunE`).
- **Output Format Validation:** Enhanced `ListOrganizations` tests to capture `os.Stdout` and validate the actual JSON and YAML output against expected structures, ensuring correct serialization and presentation.
- **Improved Error Handling Tests:** Added test cases for `ListOrgCmd` to cover scenarios where the `ClientFactory` itself returns an error, ensuring comprehensive error propagation.
- **Test Coverage Integration:** Updated the `Makefile` with `coverage` and `coverage-html` targets to easily generate and view test coverage reports.
