### PR TITLE
fix: return curl error on CS loadbalancer responses for non-started w…

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -71,15 +71,15 @@ License URL: https://github.com/cpuguy83/go-md2man/blob/v2.0.7/LICENSE.md
  
 ----------
 Module: github.com/creativeprojects/go-selfupdate
-Version: v1.5.2
+Version: v1.6.0
 License: MIT
-License URL: https://github.com/creativeprojects/go-selfupdate/blob/v1.5.2/LICENSE
+License URL: https://github.com/creativeprojects/go-selfupdate/blob/v1.6.0/LICENSE
  
 ----------
 Module: github.com/creativeprojects/go-selfupdate/update
-Version: v1.5.2
+Version: v1.6.0
 License: Apache-2.0
-License URL: https://github.com/creativeprojects/go-selfupdate/blob/v1.5.2/update/LICENSE
+License URL: https://github.com/creativeprojects/go-selfupdate/blob/v1.6.0/update/LICENSE
  
 ----------
 Module: github.com/cyphar/filepath-securejoin
@@ -148,10 +148,10 @@ License: BSD-3-Clause
 License URL: https://github.com/google/go-cmp/blob/v0.7.0/LICENSE
  
 ----------
-Module: github.com/google/go-github/v74/github
-Version: v74.0.0
+Module: github.com/google/go-github/v86/github
+Version: v86.0.0
 License: BSD-3-Clause
-License URL: https://github.com/google/go-github/blob/v74.0.0/LICENSE
+License URL: https://github.com/google/go-github/blob/v86.0.0/LICENSE
  
 ----------
 Module: github.com/google/go-querystring/query
@@ -491,9 +491,9 @@ License URL: https://cs.opensource.google/go/x/sync/+/v0.21.0:LICENSE
  
 ----------
 Module: golang.org/x/sys
-Version: v0.46.0
+Version: v0.47.0
 License: BSD-3-Clause
-License URL: https://cs.opensource.google/go/x/sys/+/v0.46.0:LICENSE
+License URL: https://cs.opensource.google/go/x/sys/+/v0.47.0:LICENSE
  
 ----------
 Module: golang.org/x/text

--- a/cli/cmd/client.go
+++ b/cli/cmd/client.go
@@ -43,7 +43,9 @@ type Client interface {
 
 // CommandExecutor abstracts command execution for testing
 type CommandExecutor interface {
-	Execute(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error
+	// Execute runs the command, streaming to stdout/stderr as usual, and additionally
+	// returns the combined stdout+stderr output that was written.
+	Execute(ctx context.Context, name string, args []string, stdout, stderr io.Writer) (string, error)
 }
 
 func NewClient(opts GlobalOptions) (Client, error) {

--- a/cli/cmd/curl.go
+++ b/cli/cmd/curl.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -20,11 +21,19 @@ import (
 // DefaultCommandExecutor uses os/exec to run commands
 type DefaultCommandExecutor struct{}
 
-func (e *DefaultCommandExecutor) Execute(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {
+func (e *DefaultCommandExecutor) Execute(ctx context.Context, name string, args []string, stdout, stderr io.Writer) (string, error) {
+	var output bytes.Buffer
+
 	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-	return cmd.Run()
+	cmd.Stdout = io.MultiWriter(stdout, &output)
+	cmd.Stderr = io.MultiWriter(stderr, &output)
+
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("execute curl failed: %w", err)
+	}
+
+	return output.String(), err
 }
 
 type CurlOptions struct {
@@ -77,7 +86,8 @@ func AddCurlCmd(rootCmd *cobra.Command, opts *GlobalOptions) {
 				{Cmd: "/api/data -w 1234 -- -XPOST -d '{\"key\":\"value\"}'", Desc: "POST request with data"},
 				{Cmd: "/api/endpoint -w 1234 -- -v", Desc: "verbose output"},
 				{Cmd: "-w 1234 -- -v", Desc: "verbose request to workspace root"},
-				{Cmd: "/ -- -k", Desc: "skip TLS verification"}, {Cmd: "/ -- -I", Desc: "HEAD request using workspace from env var"},
+				{Cmd: "/ -- -k", Desc: "skip TLS verification"},
+				{Cmd: "/ -- -I", Desc: "HEAD request using workspace from env var"},
 			}),
 			Args: cobra.ArbitraryArgs,
 		},
@@ -117,10 +127,33 @@ func (c *CurlCmd) CurlWorkspace(client Client, wsId int, token string, path stri
 	cmdArgs = append(cmdArgs, curlArgs...)
 	cmdArgs = append(cmdArgs, url)
 
-	err = c.Opts.Executor.Execute(ctx, cmdArgs[0], cmdArgs[1:], os.Stdout, os.Stderr)
+	output, err := c.Opts.Executor.Execute(ctx, cmdArgs[0], cmdArgs[1:], os.Stdout, os.Stderr)
 	if err != nil && err == context.DeadlineExceeded {
 		return fmt.Errorf("timeout exceeded while requesting workspace %d", wsId)
 	}
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	if err = c.checkOutput(output); err != nil {
+		return fmt.Errorf("invalid output: %w", err)
+	}
+
+	return nil
+}
+
+func (c *CurlCmd) checkOutput(output string) error {
+	errorMessages := []string{
+		"Too Many Requests",
+		"Workspace server is starting",
+	}
+
+	for _, msg := range errorMessages {
+		if strings.Contains(output, msg) {
+			return fmt.Errorf("workspace not running. Found '%s' in output", msg)
+		}
+	}
+
+	return nil
 }

--- a/cli/cmd/curl_test.go
+++ b/cli/cmd/curl_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Curl", func() {
 				}),
 				mock.Anything,
 				mock.Anything,
-			).Return(nil)
+			).Return("", nil)
 
 			err := c.CurlWorkspace(mockClient, wsId, token, "/api/health", []string{"-I"})
 
@@ -116,7 +116,7 @@ var _ = Describe("Curl", func() {
 				}),
 				mock.Anything,
 				mock.Anything,
-			).Return(nil)
+			).Return("", nil)
 
 			err := c.CurlWorkspace(mockClient, wsId, token, "/custom/path", []string{})
 
@@ -156,12 +156,46 @@ var _ = Describe("Curl", func() {
 				mock.Anything,
 				mock.Anything,
 				mock.Anything,
-			).Return(fmt.Errorf("command failed"))
+			).Return("", fmt.Errorf("command failed"))
 
 			err := c.CurlWorkspace(mockClient, wsId, token, "/", []string{})
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("command failed"))
+		})
+
+		It("should return error if output contains 'Too Many Requests' message", func() {
+			mockClient.EXPECT().GetWorkspace(wsId).Return(workspace, nil)
+			mockExecutor.EXPECT().Execute(
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			).Return("Too Many Requests", nil)
+
+			err := c.CurlWorkspace(mockClient, wsId, token, "/", []string{})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid output"))
+			Expect(err.Error()).To(ContainSubstring("workspace not running. Found 'Too Many Requests' in output"))
+		})
+
+		It("should return error if output contains 'Workspace server is starting' message", func() {
+			mockClient.EXPECT().GetWorkspace(wsId).Return(workspace, nil)
+			mockExecutor.EXPECT().Execute(
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			).Return("Workspace server is starting", nil)
+
+			err := c.CurlWorkspace(mockClient, wsId, token, "/", []string{})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid output"))
+			Expect(err.Error()).To(ContainSubstring("workspace not running. Found 'Workspace server is starting' in output"))
 		})
 	})
 })

--- a/cli/cmd/mocks.go
+++ b/cli/cmd/mocks.go
@@ -1461,20 +1461,29 @@ func (_m *MockCommandExecutor) EXPECT() *MockCommandExecutor_Expecter {
 }
 
 // Execute provides a mock function for the type MockCommandExecutor
-func (_mock *MockCommandExecutor) Execute(ctx context.Context, name string, args []string, stdout io.Writer, stderr io.Writer) error {
+func (_mock *MockCommandExecutor) Execute(ctx context.Context, name string, args []string, stdout io.Writer, stderr io.Writer) (string, error) {
 	ret := _mock.Called(ctx, name, args, stdout, stderr)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, io.Writer, io.Writer) error); ok {
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, io.Writer, io.Writer) (string, error)); ok {
+		return returnFunc(ctx, name, args, stdout, stderr)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, io.Writer, io.Writer) string); ok {
 		r0 = returnFunc(ctx, name, args, stdout, stderr)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(string)
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string, io.Writer, io.Writer) error); ok {
+		r1 = returnFunc(ctx, name, args, stdout, stderr)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // MockCommandExecutor_Execute_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Execute'
@@ -1525,12 +1534,12 @@ func (_c *MockCommandExecutor_Execute_Call) Run(run func(ctx context.Context, na
 	return _c
 }
 
-func (_c *MockCommandExecutor_Execute_Call) Return(err error) *MockCommandExecutor_Execute_Call {
-	_c.Call.Return(err)
+func (_c *MockCommandExecutor_Execute_Call) Return(s string, err error) *MockCommandExecutor_Execute_Call {
+	_c.Call.Return(s, err)
 	return _c
 }
 
-func (_c *MockCommandExecutor_Execute_Call) RunAndReturn(run func(ctx context.Context, name string, args []string, stdout io.Writer, stderr io.Writer) error) *MockCommandExecutor_Execute_Call {
+func (_c *MockCommandExecutor_Execute_Call) RunAndReturn(run func(ctx context.Context, name string, args []string, stdout io.Writer, stderr io.Writer) (string, error)) *MockCommandExecutor_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/tmpl/NOTICE
+++ b/pkg/tmpl/NOTICE
@@ -71,15 +71,15 @@ License URL: https://github.com/cpuguy83/go-md2man/blob/v2.0.7/LICENSE.md
  
 ----------
 Module: github.com/creativeprojects/go-selfupdate
-Version: v1.5.2
+Version: v1.6.0
 License: MIT
-License URL: https://github.com/creativeprojects/go-selfupdate/blob/v1.5.2/LICENSE
+License URL: https://github.com/creativeprojects/go-selfupdate/blob/v1.6.0/LICENSE
  
 ----------
 Module: github.com/creativeprojects/go-selfupdate/update
-Version: v1.5.2
+Version: v1.6.0
 License: Apache-2.0
-License URL: https://github.com/creativeprojects/go-selfupdate/blob/v1.5.2/update/LICENSE
+License URL: https://github.com/creativeprojects/go-selfupdate/blob/v1.6.0/update/LICENSE
  
 ----------
 Module: github.com/cyphar/filepath-securejoin
@@ -148,10 +148,10 @@ License: BSD-3-Clause
 License URL: https://github.com/google/go-cmp/blob/v0.7.0/LICENSE
  
 ----------
-Module: github.com/google/go-github/v74/github
-Version: v74.0.0
+Module: github.com/google/go-github/v86/github
+Version: v86.0.0
 License: BSD-3-Clause
-License URL: https://github.com/google/go-github/blob/v74.0.0/LICENSE
+License URL: https://github.com/google/go-github/blob/v86.0.0/LICENSE
  
 ----------
 Module: github.com/google/go-querystring/query
@@ -491,9 +491,9 @@ License URL: https://cs.opensource.google/go/x/sync/+/v0.21.0:LICENSE
  
 ----------
 Module: golang.org/x/sys
-Version: v0.46.0
+Version: v0.47.0
 License: BSD-3-Clause
-License URL: https://cs.opensource.google/go/x/sys/+/v0.46.0:LICENSE
+License URL: https://cs.opensource.google/go/x/sys/+/v0.47.0:LICENSE
  
 ----------
 Module: golang.org/x/text


### PR DESCRIPTION
When workspaces are not started, we return success in `cs curl`, but it should be an error instead. Therefore filtering for 2 common  load balancer responses to return an error.

This one example response for a stopped workspace, which is now handled with an error exit code:

```
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <meta http-equiv="refresh" content="3">
    <title>Codesphere Error</title>

    <link rel="preconnect" href="https://fonts.googleapis.com">
    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">

    <style>
        * {
            margin-block-end: 0;
            margin-block-start: 0;
        }

        body {
            font-family: 'Inter', sans-serif;
            color: #18181B;
        }

        h1 {
            font-weight: 500;
            font-size: 1.875rem;
            line-height: 1.875rem;
        }

        p {
            font-weight: 400;
            font-size: .875rem;
            line-height: 1.25rem;
            text-align: center;
        }

        body {
            margin: 0;
            padding: 0;
            min-height: 100vh;
            display: flex;
            align-items: center;
            justify-content: center;
            overflow-y: auto;
        }

        .main {
            display: flex;
            flex-direction: column;
            gap: 1.5rem;
            align-items: center;
            justify-content: center;
            max-width: 40rem;
            padding: 1rem;
        }

        .text-content {
            display: flex;
            flex-direction: column;
            gap: 1rem;
            align-items: center;
            justify-content: center;
        }

        .container {
            display: flex;
            flex-direction: column;
            align-items: center;
            justify-content: center;
            gap: 1.5rem;
        }

        .error-code {
            font-weight: 700;
            font-size: 6rem;
            line-height: 6rem;
            color: #52525b;
        }

        .btn {
            background-color: #814BF6;
            color: white;
            text-decoration: none;
            padding: 0.5rem 1rem;
            border-radius: 0.25rem;
            font-weight: 500;
            font-size: 0.875rem;
            line-height: 1.25rem;
        }
    </style>
</head>
<body>
    <div class="main">
        <div class="error-code">429</div>
        <div class="container">
            <div class="text-content">
                <h1>Too Many Requests.</h1>
                <p>
                    This can happen if the workspace was stopped or hasn’t been set up properly. You can retry starting your application using this domain in 10 minutes.
                </p>
            </div>
            <a class="btn" href="https://cloud.codesphere.com/ide">
                Go Back to Workspaces
            </a>
        </div>
    </div>
</body>
</html>
```
